### PR TITLE
First pass of provisioner UI

### DIFF
--- a/aws-provisioner/app.jsx
+++ b/aws-provisioner/app.jsx
@@ -1,0 +1,17 @@
+/** @jsx React.DOM */
+var React                   = require('react');
+var $                       = require('jquery');
+var bs                      = require('react-bootstrap');
+var AwsProvisioner          = require('./awsprovisioner');
+var utils                   = require('../lib/utils');
+
+// Render component
+$(function() {
+  React.render(
+    (
+      <AwsProvisioner />
+    ),
+    $('#container')[0]
+  );
+});
+

--- a/aws-provisioner/app.less
+++ b/aws-provisioner/app.less
@@ -1,0 +1,2 @@
+@import "awsprovisioner.less";
+

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -66,8 +66,8 @@ var WorkerTypeTable = React.createClass({
   load: function() {
     return {
       workerTypes: this.awsProvisioner.listWorkerTypes(),
-      //awsState: this.awsProvisioner.updateAwsState(),
-      awsState: this.awsProvisioner.awsState(),
+      awsState: this.awsProvisioner.updateAwsState(),
+      //awsState: this.awsProvisioner.awsState(),
     };
   },
   
@@ -180,7 +180,7 @@ var WorkerTypeRow = React.createClass({
         });
       });
 
-      s.pending.forEach(function(node) {
+      s.spotReq.forEach(function(node) {
         w.instanceTypes.forEach(function(itd) {
           if (itd.instanceType === node.LaunchSpecification.InstanceType) {
             console.log('Adding ' + itd.capacity + ' to requested capacity');

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -66,6 +66,7 @@ var WorkerTypeTable = React.createClass({
   load: function() {
     return {
       workerTypes: this.awsProvisioner.listWorkerTypes(),
+      //awsState: this.awsProvisioner.updateAwsState(),
       awsState: this.awsProvisioner.awsState(),
     };
   },
@@ -135,12 +136,10 @@ var WorkerTypeRow = React.createClass({
 
   getInitialState: function() {
     return {
-      pendingTasks: {
-        pendingTasks: 'loading',  
-      },
+      pendingTasks: {},
       pendingTasksLoaded: true,
       pendingTasksError: undefined,
-      workerType: 'loading',
+      workerType: undefined,
       workerTypeLoaded: true,
       workerTypeError: undefined,
     };
@@ -154,13 +153,16 @@ var WorkerTypeRow = React.createClass({
   },
 
   render: function() {
-    return this.renderWaitFor('pendingTasks') ||
-           this.renderWaitFor('workerType') ||
-    (<tr>
+    var that = this;
+    var runningCapacity = 0;
+    var pendingCapacity = 0;
+    var spotReqCapacity = 0;
+    
+    return this.renderWaitFor('pendingTasks') || this.renderWaitFor('workerType') || (<tr>
       <td>{this.props.workerType}</td>
-      <td>{this.props.awsState.running.length}</td>
-      <td>{this.props.awsState.pending.length}</td>
-      <td>{this.props.awsState.spotReq.length}</td>
+      <td>{runningCapacity} ({this.props.awsState.running.length})</td>
+      <td>{pendingCapacity} ({this.props.awsState.pending.length})</td>
+      <td>{spotReqCapacity} ({this.props.awsState.spotReq.length})</td>
       <td>{this.state.pendingTasks.pendingTasks}</td>
       <td>
         <bs.ButtonToolbar>
@@ -188,7 +190,12 @@ var WorkerTypeRow = React.createClass({
     p.catch(function(err) {
       console.error(err);
       if (err.stack) console.log(err.stack);
-      alert('Failed to delete ' + that.props.workerType);
+      if (err.statusCode === 404) {
+        console.log('Tried to delete ' + that.props.workerType + ' but it does not exist.');
+        console.log('Maybe you already clicked this button!');
+      } else {
+        alert('Failed to delete ' + that.props.workerType);
+      }
     });
 
     p.done();

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -157,6 +157,40 @@ var WorkerTypeRow = React.createClass({
     var runningCapacity = 0;
     var pendingCapacity = 0;
     var spotReqCapacity = 0;
+
+    if (this.state.workerType) {
+      console.log('Rendering a row with a loaded workerType');
+      var s = this.props.awsState;
+      var w = this.state.workerType;
+      
+      s.running.forEach(function(node) {
+        w.instanceTypes.forEach(function(itd) {
+          if (itd.instanceType === node.InstanceType) {
+            console.log('Adding ' + itd.capacity + ' to running capacity');
+            runningCapacity += itd.capacity;
+          }
+        });
+      });
+
+      s.pending.forEach(function(node) {
+        w.instanceTypes.forEach(function(itd) {
+          if (itd.instanceType === node.InstanceType) {
+            console.log('Adding ' + itd.capacity + ' to pending capacity');
+            runningCapacity += itd.capacity;
+          }
+        });
+      });
+
+      s.pending.forEach(function(node) {
+        w.instanceTypes.forEach(function(itd) {
+          if (itd.instanceType === node.LaunchSpecification.InstanceType) {
+            console.log('Adding ' + itd.capacity + ' to requested capacity');
+            runningCapacity += itd.capacity;
+          }
+        });
+      });
+
+    }
     
     return this.renderWaitFor('pendingTasks') || this.renderWaitFor('workerType') || (<tr>
       <td>{this.props.workerType}</td>

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -1,0 +1,46 @@
+/** @jsx React.DOM */
+var React           = require('react');
+var bs              = require('react-bootstrap');
+var utils           = require('../lib/utils');
+var taskcluster     = require('taskcluster-client');
+var _               = require('lodash');
+var format          = require('../lib/format');
+
+/** Generic Index Browser with a custom entryView */
+var AwsProvisioner = React.createClass({
+  mixins: [
+    // Calls load()
+    utils.createTaskClusterMixin({
+      clients: {
+        awsProvisioner:          taskcluster.Index
+      },
+      // Reload when state.namespace changes, ignore credentials changes
+      reloadOnKeys:           ['workerType'],
+      reloadOnLogin:          true
+    }),
+  ],
+
+  propTypes: {
+  },
+
+  getInitialState: function() {
+    return {
+      workerType:       "",
+    };
+  },
+
+  load: function() {
+    return {
+    };
+  },
+
+  render: function() {
+    return (
+        <p>Hello</p>
+    );
+  },
+
+});
+
+// Export IndexBrowser
+module.exports = AwsProvisioner;

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -190,13 +190,57 @@ var WorkerTypeRow = React.createClass({
       });
     }
 
-    var percentRunning = runningCapacity / maxCapacity * 100;
-    var percentPending = pendingCapacity / maxCapacity * 100;
-    var requestedCapacity = spotReqCapacity / maxCapacity * 100;
+    console.log(this.props.workerType + 'running: ' + runningCapacity +
+                ' pending: ' + pendingCapacity + ' requested: ' + spotReqCapacity);
+    var percentRunning;
+    var percentPending;
+    var percentRequested;
+
+    var runningBar;
+    var pendingBar;
+    var requestedBar;
+    var excessBar;
+
+    // This is the difference to subtract from the largest... maybe
+    var offset = 0;
+
+    var key = 1;
+    if (runningCapacity > 0) {
+      percentRunning = runningCapacity / maxCapacity * 100;
+      if (percentRunning > 0 && percentRunning < 5) {
+        var diff = 5 - percentRunning;
+        percentRunning = 5;
+        offset += diff;
+      }
+      runningBar = <bs.ProgressBar bsStyle='success' now={percentRunning} key={key++} label={runningCapacity} />
+    }
+    if (pendingCapacity > 0) {
+      percentPending = pendingCapacity / maxCapacity * 100;
+      if (percentPending > 0 && percentPending < 5) {
+        var diff = 5 - percentPending;
+        percentPending = 5;
+        offset += diff;
+      }
+      pendingBar = <bs.ProgressBar bsStyle='info' now={percentPending} key={key++} label={pendingCapacity} />
+    }
+    if (spotReqCapacity > 0) {
+      percentRequested = spotReqCapacity / maxCapacity * 100;
+      if (percentRequested > 0 && percentRequested < 5) {
+        var diff = 5 - percentRequested;
+        percentRequested = 5;
+        offset += diff;
+      }
+      requestedBar = <bs.ProgressBar bsStyle='warning' now={percentRequested} key={key++} label={spotReqCapacity} />
+    }
+
+    // TODO Figure out a way to show this as a class danger probably
+    var excess = (runningCapacity + pendingCapacity + spotReqCapacity) - maxCapacity;
+    console.log(excess);
+
     var progressBar = (<bs.ProgressBar>
-      <bs.ProgressBar bsStyle='success' now={percentRunning} key={1} label={runningCapacity} />
-      <bs.ProgressBar bsStyle='info' now={percentPending} key={2} label={pendingCapacity} />
-      <bs.ProgressBar bsStyle='warning' now={requestedCapacity} key={3} label={spotReqCapacity} />
+        {runningBar ? runningBar : ''}
+        {pendingBar ? pendingBar: ''}
+        {requestedBar ? requestedBar : ''}
     </bs.ProgressBar>);
 
     

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -6,7 +6,81 @@ var taskcluster     = require('taskcluster-client');
 var _               = require('lodash');
 var format          = require('../lib/format');
 
-/** Generic Index Browser with a custom entryView */
+/** 
+ * We are doing this without the mixin for now because the client needs
+ * to be created in a non-standard way.  This shouldn't be done this way
+ * in production...
+ */
+/** BEGIN SUPER HACK */
+var request = new XMLHttpRequest();
+//request.open('GET', 'https://taskcluster-aws-provisioner2.herokuapp.com/v1/api-reference', false);
+request.open('GET', 'http://localhost:5556/v1/api-reference', false);
+request.send(null);
+if (request.status === 200) {
+  var reftxt = request.responseText;
+  try {
+    var reference = JSON.parse(reftxt);
+    console.dir(reference);
+  } catch(e) {
+    console.log(e, e.stack);
+    alert('Uh-oh, error: ' + e);
+  }
+} else {
+  alert('Uh-oh, failed to load API reference');
+}
+
+var AwsProvisionerClient = taskcluster.createClient(reference);
+/** END SUPER HACK */
+
+// Questions:
+//  1. Should I create a client for each react class or share the parent classes?
+//  2. Why does the aws-provisioner not allow cross-origin requests?
+
+
+var WorkerTypeTable = React.createClass({
+  mixins: [
+    utils.createTaskClusterMixin({
+      clients: {
+        awsProvisioner: AwsProvisionerClient,
+      }
+    }),
+  ],
+
+  getInitialState: function() {
+    return {
+      workerTypes: [],
+      workerTypesLoaded: true,
+      workerTypesError: undefined,
+      current: '',
+    };
+  },
+
+  load: function() {
+    return {
+      workerTypes: this.awsProvisioner.listWorkerTypes(),
+    };
+  },
+  
+  render: function() {
+    return (
+      <bs.Table striped bordered condensed hover>
+        <thead>
+          <tr>
+            <th>Worker Type Name</th>
+          </tr>
+        </thead>
+        <tbody>
+        {
+          this.renderWaitFor('workerTypes') || this.state.workerTypes.map(function(name) {
+            return (<tr><td>{name}</td></tr>);
+          })
+        }
+        </tbody>
+      </bs.Table>
+    );
+  },
+});
+
 var AwsProvisioner = React.createClass({
   mixins: [
     // Calls load()
@@ -14,9 +88,6 @@ var AwsProvisioner = React.createClass({
       clients: {
         awsProvisioner:          taskcluster.Index
       },
-      // Reload when state.namespace changes, ignore credentials changes
-      reloadOnKeys:           ['workerType'],
-      reloadOnLogin:          true
     }),
   ],
 
@@ -25,7 +96,7 @@ var AwsProvisioner = React.createClass({
 
   getInitialState: function() {
     return {
-      workerType:       "",
+      workerType: "",
     };
   },
 
@@ -36,7 +107,7 @@ var AwsProvisioner = React.createClass({
 
   render: function() {
     return (
-        <p>Hello</p>
+        <WorkerTypeTable />
     );
   },
 

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -62,17 +62,28 @@ var WorkerTypeTable = React.createClass({
   },
   
   render: function() {
+    // TODO: Should write a note somewhere explaining what all these terms mean
     return (
       <bs.Table striped bordered condensed hover>
         <thead>
           <tr>
             <th>Worker Type Name</th>
+            <th>Running Capacity</th>
+            <th>Pending Capacity</th>
+            <th>Requested Capacity</th>
+            <th>Pending Tasks</th>
           </tr>
         </thead>
         <tbody>
         {
           this.renderWaitFor('workerTypes') || this.state.workerTypes.map(function(name) {
-            return (<tr><td>{name}</td></tr>);
+            return (<tr key={name}>
+              <td>{name}</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>);
           })
         }
         </tbody>

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -9,14 +9,11 @@ var format          = require('../lib/format');
 // Should this be allowed to be set by user?
 var provisionerId = 'aws-provisioner2-dev';
 
-/** 
- * We are doing this without the mixin for now because the client needs
- * to be created in a non-standard way.  This shouldn't be done this way
- * in production...
- */
 /** BEGIN SUPER HACK */
 var request = new XMLHttpRequest();
 //request.open('GET', 'https://taskcluster-aws-provisioner2.herokuapp.com/v1/api-reference', false);
+console.log('ignore this deprecation... once the API is in the upstream client we wont need '+
+            'to do this anymore');
 request.open('GET', 'http://localhost:5556/v1/api-reference', false);
 request.send(null);
 if (request.status === 200) {
@@ -31,7 +28,6 @@ if (request.status === 200) {
 } else {
   alert('Uh-oh, failed to load API reference');
 }
-
 var AwsProvisionerClient = taskcluster.createClient(reference);
 /** END SUPER HACK */
 
@@ -75,7 +71,7 @@ var WorkerTypeTable = React.createClass({
             <th>Pending Capacity</th>
             <th>Requested Capacity</th>
             <th>Pending Tasks</th>
-            <th>Details/Edit</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -122,7 +118,6 @@ var WorkerTypeRow = React.createClass({
   },
 
   load: function() {
-    console.log('loading');
     return {
       awsState: Promise.resolve({
         runningCapacity: 1,
@@ -143,15 +138,19 @@ var WorkerTypeRow = React.createClass({
       <td>{this.state.awsState.requestedCapacity}</td>
       <td>{this.state.pendingTasks.pendingTasks}</td>
       <td>
-        <bs.Button bsStyle='primary' bsSize='xsmall' onClick={this.handleButton}>
-        Edit</bs.Button>
+        <bs.ButtonToolbar>
+        <bs.Button bsStyle='primary' bsSize='xsmall' onClick={this.handleDetails}>Details</bs.Button>
+        {/* Hmm, should I allow deleting from here or should that only be under details...*/}
+        {/*<bs.Button bsStyle='danger' bsSize='xsmall' onClick={this.handleDelete}>Delete</bs.Button>*/}
+        </bs.ButtonToolbar>
       </td>
     </tr>);  
   },
 
-  handleButton: function() {
-    alert('Pity da fool');
+  handleDetails: function() {
+    alert('details ' + this.props.workerType);
   },
+
 });
 
 var AwsProvisioner = React.createClass({
@@ -159,7 +158,7 @@ var AwsProvisioner = React.createClass({
     // Calls load()
     utils.createTaskClusterMixin({
       clients: {
-        awsProvisioner:          taskcluster.Index
+        awsProvisioner: taskcluster.Index
       },
     }),
   ],

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -7,14 +7,14 @@ var _               = require('lodash');
 var format          = require('../lib/format');
 
 // Should this be allowed to be set by user?
-var provisionerId = 'aws-provisioner2-dev';
+var provisionerId = 'aws-provisioner2';
 
 /** BEGIN SUPER HACK */
 var request = new XMLHttpRequest();
-//request.open('GET', 'https://taskcluster-aws-provisioner2.herokuapp.com/v1/api-reference', false);
 console.log('ignore this deprecation... once the API is in the upstream client we wont need '+
             'to do this anymore');
-request.open('GET', 'http://localhost:5556/v1/api-reference', false);
+request.open('GET', 'https://taskcluster-aws-provisioner2.herokuapp.com/v1/api-reference', false);
+//request.open('GET', 'http://localhost:5556/v1/api-reference', false);
 request.send(null);
 if (request.status === 200) {
   var reftxt = request.responseText;
@@ -27,6 +27,12 @@ if (request.status === 200) {
   }
 } else {
   alert('Uh-oh, failed to load API reference');
+}
+//console.log('HIHIHIHH' + reference.baseUrl);
+if (reference.baseUrl[4] !== 's') {
+  console.log(reference.baseUrl);
+  reference.baseUrl = 'https://' + reference.baseUrl.slice(7);
+  console.log(reference.baseUrl);
 }
 var AwsProvisionerClient = taskcluster.createClient(reference);
 /** END SUPER HACK */

--- a/aws-provisioner/awsprovisioner.jsx
+++ b/aws-provisioner/awsprovisioner.jsx
@@ -6,6 +6,9 @@ var taskcluster     = require('taskcluster-client');
 var _               = require('lodash');
 var format          = require('../lib/format');
 
+// Should this be allowed to be set by user?
+var provisionerId = 'aws-provisioner2-dev';
+
 /** 
  * We are doing this without the mixin for now because the client needs
  * to be created in a non-standard way.  This shouldn't be done this way
@@ -72,23 +75,82 @@ var WorkerTypeTable = React.createClass({
             <th>Pending Capacity</th>
             <th>Requested Capacity</th>
             <th>Pending Tasks</th>
+            <th>Details/Edit</th>
           </tr>
         </thead>
         <tbody>
         {
           this.renderWaitFor('workerTypes') || this.state.workerTypes.map(function(name) {
-            return (<tr key={name}>
-              <td>{name}</td>
-              <td>0</td>
-              <td>0</td>
-              <td>0</td>
-              <td>0</td>
-            </tr>);
+            return <WorkerTypeRow key={name} workerType={name} />;
           })
         }
         </tbody>
       </bs.Table>
     );
+  },
+});
+
+var WorkerTypeRow = React.createClass({
+  mixins: [
+    utils.createTaskClusterMixin({
+      clients: {
+        awsProvisioner: AwsProvisionerClient,
+        queue: taskcluster.Queue,
+      },
+    }),
+  ],
+
+  propTypes: {
+    workerType: React.PropTypes.string.isRequired,
+  },
+
+  getInitialState: function() {
+    return {
+      awsState: {
+        runningCapacity: 'loading',
+        pendingCapacity: 'loading',
+        requestedCapacity: 'loading',
+      },
+      awsStateLoaded: true,
+      awsStateError: undefined,
+      pendingTasks: {
+        pendingTasks: 'loading',  
+      },
+      pendingTasksLoaded: true,
+      pendingTasksError: undefined,
+    };
+  },
+
+  load: function() {
+    console.log('loading');
+    return {
+      awsState: Promise.resolve({
+        runningCapacity: 1,
+        pendingCapacity: 2,
+        requestedCapacity: 3
+      }),
+      pendingTasks: this.queue.pendingTasks(provisionerId, this.props.workerType),
+    };
+  },
+
+  render: function() {
+    return this.renderWaitFor('pendingTasks') ||
+           this.renderWaitFor('awsState') ||
+    (<tr>
+      <td>{this.props.workerType}</td>
+      <td>{this.state.awsState.runningCapacity}</td>
+      <td>{this.state.awsState.pendingCapacity}</td>
+      <td>{this.state.awsState.requestedCapacity}</td>
+      <td>{this.state.pendingTasks.pendingTasks}</td>
+      <td>
+        <bs.Button bsStyle='primary' bsSize='xsmall' onClick={this.handleButton}>
+        Edit</bs.Button>
+      </td>
+    </tr>);  
+  },
+
+  handleButton: function() {
+    alert('Pity da fool');
   },
 });
 

--- a/aws-provisioner/awsprovisioner.less
+++ b/aws-provisioner/awsprovisioner.less
@@ -1,0 +1,4 @@
+
+.aws-provisioner {
+  padding-bottom:     10px;
+}

--- a/aws-provisioner/index.jade
+++ b/aws-provisioner/index.jade
@@ -1,0 +1,8 @@
+extends ../lib/layout.jade
+
+block title
+  title AWS Provisioner
+
+block append head
+  link(rel="stylesheet", href="app.css")
+  script(src='app.bundle.js')

--- a/build-files.js
+++ b/build-files.js
@@ -47,6 +47,11 @@ module.exports = [
   'task-creator/app.jsx',
   'task-creator/app.less',
 
+  // Aws Provisioner
+  'aws-provisioner/index.jade',
+  'aws-provisioner/app.jsx',
+  'aws-provisioner/app.less',
+
   // Index Browser
   'index/index.jade',
   'index/app.jsx',

--- a/menu.js
+++ b/menu.js
@@ -32,6 +32,15 @@ module.exports = [
     ].join('\n')
   },
   {
+    title:          "AWS Provisioner",
+    link:           '/aws-provisioner/',
+    icon:           'wrench',
+    description: [
+      "Manage workertypes known to the AWS Provisioner and check on the status",
+      "of AWS Nodes",
+    ].join('\n')
+  },
+  {
     title:          "Authentication Manager",
     link:           '/auth/',
     icon:           'users',


### PR DESCRIPTION
This is the first pass of the provisioner ui.  Right now, it will show the stats of the running instances, a count of pending jobs and a json display of the workerType definition.

It's not done, but I'd like to deploy this first step as a way to get visibility on the provisioner deployment.

Key things which I will be changing as time goes on:

* the top level component will be something which figures out whether to show a list, detail, edit or create.  right now, i just have the list as the top level
* use the URL fragment to decide which of these views to show
* editing of worker type definitions
* creating of worker type definitions
* a 'verify' button that will preview the launchspecificions using the server's test worker type
* a details page which shows high level stats (running, pending, etc) and a list of instances with selected metadata.
* a provisioner end point which can kill a specific spot request or instance and hook it up to the UI so that the provisioner UI can kill an instance directly.