### PR TITLE
Hack to infer a script for running a task locally

### DIFF
--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -5,6 +5,7 @@ var format          = require('../format');
 var _               = require('lodash');
 var taskcluster     = require('taskcluster-client');
 var ConfirmAction   = require('./confirmaction');
+var path            = require('path');
 
 /** Displays information about a task in a tab page */
 var TaskInfo = React.createClass({
@@ -27,7 +28,7 @@ var TaskInfo = React.createClass({
   },
 
   /** Get initial state */
-  getInitialState: function() {
+  getInitialState() {
     return {
       // task definition
       taskLoaded:   false,
@@ -37,13 +38,13 @@ var TaskInfo = React.createClass({
   },
 
   /** Load task definition */
-  load: function() {
+  load() {
     return {
       task:         this.queue.task(this.props.status.taskId)
     };
   },
 
-  render: function() {
+  render() {
     // Easy references to values
     var status  = this.props.status;
     var task    = this.state.task;
@@ -172,7 +173,7 @@ var TaskInfo = React.createClass({
             task.scopes.length > 0 ? (
               <ul>
                 {
-                  task.scopes.map(function(scope, index) {
+                  task.scopes.map((scope, index) => {
                     return <li key={index}><code>{scope}</code></li>;
                   })
                 }
@@ -188,7 +189,7 @@ var TaskInfo = React.createClass({
             task.routes.length > 0 ? (
               <ul>
               {
-                task.routes.map(function(route, index) {
+                task.routes.map((route, index) => {
                   return <li key={index}><code>{route}</code></li>
                 })
               }
@@ -215,19 +216,102 @@ var TaskInfo = React.createClass({
             {JSON.stringify(task.payload, undefined, 2)}
           </format.Code>
         </dd>
+        <dt>Run Locally</dt>
+        <dd>
+          <format.Code language='bash'>
+            {this.renderRunLocallyScript()}
+          </format.Code>
+        </dd>
       </dl>
       </span>
     );
   },
 
-  scheduleTask: function() {
+  scheduleTask() {
     return this.queue.scheduleTask(this.props.status.taskId);
   },
-  rerunTask: function() {
+  rerunTask() {
     return this.queue.rerunTask(this.props.status.taskId);
   },
-  cancelTask: function() {
+  cancelTask() {
     return this.queue.cancelTask(this.props.status.taskId);
+  },
+
+  /** Render script illustrating how to run locally */
+  renderRunLocallyScript() {
+    // Note:
+    // We ignore cache folders, as they'll just be empty, which is fine.
+    // TODO: Implement support for task.payload.features such as:
+    //        - taskclusterProxy
+    //        - testdroidProxy
+    //        - balrogVPNProxy
+    //       We can do this with --link and demonstrate how to inject
+    //       credentials using environment variables
+    //       (obviously we can provide the credentials)
+    var taskId  = this.props.status.taskId;
+    var payload = this.state.task.payload;
+    if (!payload.image) {
+      return "# Failed to infer task payload format";
+    }
+    var cmds = [];
+    cmds.push("#!/bin/bash");
+    cmds.push("# WARNING: this is experimental mileage may vary!");
+    cmds.push("");
+    cmds.push("# Fetch docker image");
+    cmds.push("docker pull " + payload.image);
+    cmds.push("");
+    cmds.push("# Find a unique container name");
+    cmds.push("export $NAME='task-" + taskId + "-container';");
+    cmds.push("");
+    cmds.push("# Run docker command");
+    cmds.push("docker run -ti \\");
+    cmds.push("  --name $NAME \\");
+    if (payload.capabilities && payload.capabilities.privileged) {
+      cmds.push("  --privileged \\");
+    }
+    _.keys(payload.env || {}).forEach(key => {
+      cmds.push("  -e " + key + "='" + payload.env[key] + "' \\");
+    });
+    cmds.push("  " + payload.image + " \\");
+    if (payload.command) {
+      var command = payload.command.map(cmd => {
+        cmd = cmd.replace(/\\/g, "\\\\");
+        if (/['\n\r\t\v\b]/.test(cmd)) {
+          return "$'" + cmd.replace(/['\n\r\t\v\b]/g, c => {
+            return {
+              "'":  "\\'",
+              "\n": "\\n",
+              "\r": "\\r",
+              "\t": "\\t",
+              "\v": "\\v",
+              "\b": "\\b"
+            }[c];
+          }) + "'";
+        } else if (!/^[a-z-A-Z0-9\.,;://_-]*$/.test(cmd)) {
+          return "'" + cmd + "'";
+        }
+        return cmd;
+      }).join(' ');
+      cmds.push("  " + command + " \\");
+    }
+    cmds.push("  ;");
+    cmds.push("");
+    if (payload.artifacts) {
+      cmds.push("# Extract Artifacts");
+      _.keys(payload.artifacts).forEach(name => {
+        var src = payload.artifacts[name].path;
+        var folder = name;
+        if (payload.artifacts[name].type === 'file') {
+          folder = path.dirname(name);
+        }
+        cmds.push("mkdir -p " + folder + ";");
+        cmds.push("docker cp $NAME:" + src + " " + name + ";");
+      });
+    }
+    cmds.push("");
+    cmds.push("# Delete docker container");
+    cmds.push("docker rm -v $NAME;");
+    return cmds.join('\n');
   }
 });
 


### PR DESCRIPTION
Example:
http://postimg.org/image/kxmhmhyhj/

@gregarndt, quick review... check if what I'm doing here is crazy...
If you have a clue about how to illustrate usage of `--link` for:
 * taskclusterProxy
 * testdroidProxy
 * balrogVPNProxy
For example which docker images to use and how to inject credentials into them that would be awesome.

Obviously, we can display credentials here :)
But we can show that they are inject by env variables, example:
```bash
docker run -d \
  --name balrog-vpn-proxy \
  -e PWD=$MY_VPN_PASSWORD \
  taskcluster/balrogvpnimage:0.2.1 \
 ;

docker run -ti --link balrog-vpn-proxy ... . .. # all the things from below...
```

@gregarndt, also on a slightly crazy note...
Would it be completely insane if every instance of docker-worker uploaded a javascript file to:
`references.taskcluster.net/workers/<provisionerId>/<workerId>/run-locally.js`

Such that we can include that file on tools.taskcluster.net and use it to generate the illustrative script.
I say illustrative because it's hard to generate something that always works, but if we could just come somewhat close that would really nice.
Obviously, if using something like a special loopback video device the script returned might include a short explanation saying that you'll need to configure this very complicated thing first, he he :)

-----
I think that even if people don't use this it's very educational, in giving a quick idea of how this all works.