### PR TITLE
Changes to the provisioner UI to support the secrets/userdata changes

### DIFF
--- a/aws-provisioner/workertypeeditor.jsx
+++ b/aws-provisioner/workertypeeditor.jsx
@@ -148,18 +148,32 @@ var WorkerTypeEditor = React.createClass({
 
   async save() {
     var def = JSON.parse(this.state.definition);
-    encodeUserData(def.launchSpecification);
-    def.regions.map(_.property('overwrites')).forEach(encodeUserData);
-    def.instanceTypes.map(_.property('overwrites')).forEach(encodeUserData);
+    /*** LEGACY NOTICE: This check and the actions it does are
+         leftovers.  We'll soon be able to delete the check,
+         the actions and the functions ***/
+    if (def.launchSpecification) {
+      encodeUserData(def.launchSpecification);
+      def.regions.map(_.property('overwrites')).forEach(encodeUserData);
+      def.instanceTypes.map(_.property('overwrites')).forEach(encodeUserData);
+    } /* END LEGACY */ else {
+      delete def.lastModified; // Remember that the provisioner api sets this
+    }
     await this.awsProvisioner.updateWorkerType(this.state.workerType, def);
     await this.props.updated(this.state.workerType);
   },
 
   async create() {
     var def = JSON.parse(this.state.definition);
-    encodeUserData(def.launchSpecification);
-    def.regions.map(_.property('overwrites')).forEach(encodeUserData);
-    def.instanceTypes.map(_.property('overwrites')).forEach(encodeUserData);
+    /*** LEGACY NOTICE: This check and the actions it does are
+         leftovers.  We'll soon be able to delete the check,
+         the actions and the functions ***/
+    if (def.launchSpecification) {
+      encodeUserData(def.launchSpecification);
+      def.regions.map(_.property('overwrites')).forEach(encodeUserData);
+      def.instanceTypes.map(_.property('overwrites')).forEach(encodeUserData);
+    } /* END LEGACY */ else {
+      delete def.lastModified; // Remember that the provisioner api sets this
+    }
     await this.awsProvisioner.createWorkerType(this.state.workerType, def);
     await this.props.updated(this.state.workerType);
   },

--- a/aws-provisioner/workertypeview.jsx
+++ b/aws-provisioner/workertypeview.jsx
@@ -401,25 +401,29 @@ var WorkerTypeView = React.createClass({
 
   renderDefinition() {
     var def = _.cloneDeep(this.state.workerType);
-    if (def.launchSpecification.Userdata) {
-      def.launchSpecification.Userdata = JSON.parse(
-        new Buffer(def.launchSpecification.Userdata, 'base64')
-      );
-    }
-    def.instanceTypes.forEach(instTypeDef => {
-      if (instTypeDef.overwrites && instTypeDef.overwrites.UserData) {
-        instTypeDef.overwrites.UserData = JSON.parse(
-          new Buffer(instTypeDef.overwrites.UserData, 'base64')
+    /*** LEGACY NOTICE: This stuff is here because of the schema
+         changes for making secrets work ***/
+    if (def.launchSpecification) {
+      if (def.launchSpecification.Userdata) {
+        def.launchSpecification.Userdata = JSON.parse(
+          new Buffer(def.launchSpecification.Userdata, 'base64')
         );
       }
-    });
-    def.regions.forEach(regionDef => {
-      if (regionDef.overwrites && regionDef.overwrites.UserData) {
-        regionDef.overwrites.UserData = JSON.parse(
-          new Buffer(regionDef.overwrites.UserData, 'base64')
-        );
-      }
-    });
+      def.instanceTypes.forEach(instTypeDef => {
+        if (instTypeDef.overwrites && instTypeDef.overwrites.UserData) {
+          instTypeDef.overwrites.UserData = JSON.parse(
+            new Buffer(instTypeDef.overwrites.UserData, 'base64')
+          );
+        }
+      });
+      def.regions.forEach(regionDef => {
+        if (regionDef.overwrites && regionDef.overwrites.UserData) {
+          regionDef.overwrites.UserData = JSON.parse(
+            new Buffer(regionDef.overwrites.UserData, 'base64')
+          );
+        }
+      });
+    } // END LEGACY 
     return (
       <span>
         <br/>


### PR DESCRIPTION
support the new secrets schema changes.  because we just use JSON fields to edit things, we're basically just undoing the workarounds for the UserData as Base64 encoded json stuff.