### PR TITLE
Task Inspector tasks link to Task Graph Inspector and generate nicer bash code quoting

### DIFF
--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -164,7 +164,11 @@ var TaskInfo = React.createClass({
         <dt>SchedulerId</dt>
         <dd><code>{task.schedulerId}</code></dd>
         <dt>TaskGroupId</dt>
-        <dd><code>{task.taskGroupId}</code></dd>
+        <dd>
+          <a href={'../task-graph-inspector/#' + task.taskGroupId}>
+            {task.taskGroupId}
+          </a>
+        </dd>
       </dl>
       <dl className="dl-horizontal">
         <dt>Scopes</dt>
@@ -258,14 +262,14 @@ var TaskInfo = React.createClass({
     cmds.push("# WARNING: this is experimental mileage may vary!");
     cmds.push("");
     cmds.push("# Fetch docker image");
-    cmds.push("docker pull " + payload.image);
+    cmds.push("docker pull '" + payload.image + "'");
     cmds.push("");
     cmds.push("# Find a unique container name");
-    cmds.push("export NAME='task-" + taskId + "-container';");
+    cmds.push("export NAME='task-" + taskId + "-container'");
     cmds.push("");
     cmds.push("# Run docker command");
     cmds.push("docker run -ti \\");
-    cmds.push("  --name $NAME \\");
+    cmds.push("  --name \"${NAME}\" \\");
     if (payload.capabilities && payload.capabilities.privileged) {
       cmds.push("  --privileged \\");
     }
@@ -294,7 +298,6 @@ var TaskInfo = React.createClass({
       }).join(' ');
       cmds.push("  " + command + " \\");
     }
-    cmds.push("  ;");
     cmds.push("");
     if (payload.artifacts) {
       cmds.push("# Extract Artifacts");
@@ -304,13 +307,13 @@ var TaskInfo = React.createClass({
         if (payload.artifacts[name].type === 'file') {
           folder = path.dirname(name);
         }
-        cmds.push("mkdir -p " + folder + ";");
-        cmds.push("docker cp $NAME:" + src + " " + name + ";");
+        cmds.push("mkdir -p '" + folder + "'");
+        cmds.push("docker cp \"$NAME:" + src + "\" '" + name + "'");
       });
+      cmds.push("");
     }
-    cmds.push("");
     cmds.push("# Delete docker container");
-    cmds.push("docker rm -v $NAME;");
+    cmds.push("docker rm -v \"${NAME}\"");
     return cmds.join('\n');
   }
 });

--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -164,11 +164,17 @@ var TaskInfo = React.createClass({
         <dt>SchedulerId</dt>
         <dd><code>{task.schedulerId}</code></dd>
         <dt>TaskGroupId</dt>
-        <dd>
-          <a href={'../task-graph-inspector/#' + task.taskGroupId}>
-            {task.taskGroupId}
-          </a>
-        </dd>
+        {
+          task.schedulerId === 'task-graph-scheduler' ? (
+            <dd>
+              <a href={'../task-graph-inspector/#' + task.taskGroupId}>
+                {task.taskGroupId}
+              </a>
+            </dd>
+          ) : (
+            <dd><code>{task.taskGroupId}</code></dd>
+          )
+        }
       </dl>
       <dl className="dl-horizontal">
         <dt>Scopes</dt>

--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -308,7 +308,7 @@ var TaskInfo = React.createClass({
           folder = path.dirname(name);
         }
         cmds.push("mkdir -p '" + folder + "'");
-        cmds.push("docker cp \"$NAME:" + src + "\" '" + name + "'");
+        cmds.push("docker cp \"${NAME}:" + src + "\" '" + name + "'");
       });
       cmds.push("");
     }


### PR DESCRIPTION
Previously, TaskGraphId was shown as a plain string - with this change,
they are now shown as a hyperlink, so you can get straight from a task
to the task graph it came from.

Secondly, I've updated the "Run Locally" generated output to quote words
consistently and appropriately, and removed unnecessary ';' from end of
lines (which were redundant).

Changes tested locally and working.