### PR TITLE
Manipulate new client properties

### DIFF
--- a/auth/clients/clienteditor.jsx
+++ b/auth/clients/clienteditor.jsx
@@ -10,7 +10,6 @@ var ConfirmAction   = require('../../lib/ui/confirmaction');
 var Promise         = require('promise');
 var ScopeEditor     = require('../../lib/ui/scopeeditor');
 
-
 /** Create client editor/viewer (same thing) */
 var ClientEditor = React.createClass({
   /** Initialize mixins */
@@ -120,6 +119,16 @@ var ClientEditor = React.createClass({
                 </div>
               </div>
             )
+          }
+          {
+             this.state.client.disabled ? (
+              <div className="form-group">
+                <label className="control-label col-md-3">Disabled</label>
+                <div className="col-md-9">
+                  This client is disabled
+                </div>
+              </div>
+            ) : undefined
           }
           {
             (isEditing && !isCreating) || this.state.accessToken !== null ? (
@@ -264,6 +273,29 @@ var ClientEditor = React.createClass({
           Are you sure you want to delete credentials with clientId&nbsp;
           <code>{this.state.client.clientId}</code>?
         </ConfirmAction>
+        { this.state.client.disabled ? (
+          <ConfirmAction
+            buttonStyle='warning'
+            glyph='ok-circle'
+            disabled={this.state.working}
+            label="Enable Client"
+            action={this.enableClient}
+            success="Client enabled">
+            Are you sure you want to enable clientId&nbsp;
+            <code>{this.state.client.clientId}</code>?
+          </ConfirmAction>
+        ) : (
+          <ConfirmAction
+            buttonStyle='warning'
+            glyph='remove-circle'
+            disabled={this.state.working}
+            label="Disable Client"
+            action={this.disableClient}
+            success="Client disabled">
+            Are you sure you want to disable clientId&nbsp;
+            <code>{this.state.client.clientId}</code>?
+          </ConfirmAction>
+        )}
       </bs.ButtonToolbar>
     );
   },
@@ -402,6 +434,18 @@ var ClientEditor = React.createClass({
     let clientId = this.state.client.clientId;
     await this.auth.deleteClient(clientId);
     await this.props.reloadClientId(clientId);
+  },
+
+  async disableClient() {
+    let clientId = this.state.client.clientId;
+    await this.auth.disableClient(clientId);
+    await this.reload();
+  },
+
+  async enableClient() {
+    let clientId = this.state.client.clientId;
+    await this.auth.enableClient(clientId);
+    await this.reload();
   },
 
   /** Reset error state from operation*/

--- a/auth/clients/clienteditor.jsx
+++ b/auth/clients/clienteditor.jsx
@@ -201,17 +201,17 @@ var ClientEditor = React.createClass({
                 scopesUpdated={this.scopesUpdated} />
             </div>
           </div>
-          {
-            this.state.client.expandedScopes ? (
-              <div className="form-group">
-                <label className="control-label col-md-3">Expanded Scopes</label>
-                <div className="col-md-9">
-                  <ScopeEditor
-                    scopes={this.state.client.expandedScopes}/>
-                </div>
-              </div>
-            ) : undefined
-          }
+          <div className="form-group">
+            <label className="control-label col-md-3">Expanded Scopes</label>
+            <div className="col-md-9">
+              <span className="text-muted">Expanded scopes are determined from the client
+                scopes, expanding roles for scopes beginning with <code>assume:</code>.
+                The role <code>client-id:{this.state.client.clientId}</code> is implicitly
+                included.</span>
+              <ScopeEditor
+                scopes={this.state.client.expandedScopes}/>
+            </div>
+          </div>
           <hr/>
           <div className="form-group">
             <div className="col-md-9 col-md-offset-3">

--- a/auth/clients/clienteditor.jsx
+++ b/auth/clients/clienteditor.jsx
@@ -8,6 +8,7 @@ var format          = require('../../lib/format');
 var _               = require('lodash');
 var ConfirmAction   = require('../../lib/ui/confirmaction');
 var Promise         = require('promise');
+var ScopeEditor     = require('../../lib/ui/scopeeditor');
 
 
 /** Create client editor/viewer (same thing) */
@@ -191,12 +192,22 @@ var ClientEditor = React.createClass({
               );
             })
           }
+          <div className="form-group">
+            <label className="control-label col-md-3">Client Scopes</label>
+            <div className="col-md-9">
+              <ScopeEditor
+                editing={isEditing}
+                scopes={this.state.client.scopes}
+                scopesUpdated={this.scopesUpdated} />
+            </div>
+          </div>
           {
             this.state.client.expandedScopes ? (
               <div className="form-group">
-                <label className="control-label col-md-3">Scopes</label>
+                <label className="control-label col-md-3">Expanded Scopes</label>
                 <div className="col-md-9">
-                  {this.renderScopes(this.state.client.expandedScopes)}
+                  <ScopeEditor
+                    scopes={this.state.client.expandedScopes}/>
                 </div>
               </div>
             ) : undefined
@@ -302,6 +313,13 @@ var ClientEditor = React.createClass({
     this.setState(state);
   },
 
+  scopesUpdated(scopes) {
+    var client = _.cloneDeep(this.state.client);
+    client.scopes = scopes;
+    this.setState({client});
+  },
+
+
   /** When expires exchanges in the editor */
   onExpiresChange(date) {
     if (date instanceof Date) {
@@ -309,19 +327,6 @@ var ClientEditor = React.createClass({
       state.client.expires = date.toJSON();
       this.setState(state);
     }
-  },
-
-  /** Render a list of scopes */
-  renderScopes(scopes) {
-    return (
-      <ul className="form-control-static" style={{paddingLeft: 20}}>
-        {
-          scopes.map(function(scope, index) {
-            return <li key={index}><code>{scope}</code></li>;
-          })
-        }
-      </ul>
-    );
   },
 
   /** Reset accessToken for current client */

--- a/auth/clients/clientmanager.jsx
+++ b/auth/clients/clientmanager.jsx
@@ -109,8 +109,10 @@ var ClientManager = React.createClass({
   },
 
   async reloadClientId(clientId) {
+console.log("reload", clientId);
     // Load client ignore errors (assume client doesn't exist)
     let client = await this.auth.client(clientId).catch(() => null);
+console.log("reload", client);
     let selectedClientId = this.state.selectedClientId;
     let clients = _.cloneDeep(this.state.clients);
     var index = _.findIndex(clients, c => c.clientId === clientId);

--- a/auth/roles/roleeditor.jsx
+++ b/auth/roles/roleeditor.jsx
@@ -7,6 +7,7 @@ var format          = require('../../lib/format');
 var _               = require('lodash');
 var ConfirmAction   = require('../../lib/ui/confirmaction');
 var Promise         = require('promise');
+var ScopeEditor     = require('../../lib/ui/scopeeditor');
 
 
 /** Create role editor/viewer (same thing) */
@@ -87,6 +88,7 @@ var RoleEditor = React.createClass({
     if (!isCreating) {
       title = (isEditing ? "Edit Role" : "View Role");
     }
+    try {
     return this.renderWaitFor('role') || (
       <span className="role-editor">
         <h3>{title}</h3>
@@ -145,12 +147,10 @@ var RoleEditor = React.createClass({
           <div className="form-group">
             <label className="control-label col-md-3">Scopes</label>
             <div className="col-md-9">
-              {
-                isEditing ?
-                  this.renderScopeEditor()
-                :
-                  this.renderScopes(this.state.role.scopes)
-              }
+              <ScopeEditor
+                editing={isEditing}
+                scopes={this.state.role.scopes}
+                scopesUpdated={this.scopesUpdated} />
             </div>
           </div>
           {
@@ -160,7 +160,7 @@ var RoleEditor = React.createClass({
                   Expanded Scopes
                 </label>
                 <div className="col-md-9">
-                  {this.renderScopes(this.state.role.expandedScopes)}
+                  <ScopeEditor scopes={this.state.role.expandedScopes}/>
                 </div>
               </div>
             ) : undefined
@@ -191,6 +191,9 @@ var RoleEditor = React.createClass({
         </div>
       </span>
     );
+    } catch(e) {
+      console.log(e);
+    }
   },
 
   /** Determine if roleId is valid */
@@ -266,79 +269,11 @@ var RoleEditor = React.createClass({
     this.setState(state);
   },
 
-  /** Render scopes and associated editor */
-  renderScopeEditor() {
-    return (
-      <div className="form-control-static">
-        <ul style={{paddingLeft: 20}}>
-          {
-            this.state.role.scopes.map((scope, index) => {
-              return (
-                <li key={index}>
-                  <code>{scope}</code>
-                  &nbsp;
-                  <bs.Button
-                    className="role-editor-remove-scope-btn"
-                    bsStyle="danger"
-                    bsSize="xsmall"
-                    onClick={this.removeScope.bind(this, index)}>
-                    <bs.Glyphicon glyph="trash"/>
-                  </bs.Button>
-                </li>
-              );
-            }, this)
-          }
-        </ul>
-        <div className="input-group">
-          <input
-            type="text"
-            className="form-control"
-            placeholder="new-scope:for-something:*"
-            ref="newScope"/>
-          <span className="input-group-btn">
-            <button className="btn btn-success"
-                    type="button" onClick={this.addScope}>
-              <bs.Glyphicon glyph="plus"/>
-              &nbsp;
-              Add
-            </button>
-          </span>
-        </div>
-      </div>
-    );
-  },
-
   /** Add scope to state */
-  addScope() {
-    var scope = this.refs.newScope.getDOMNode().value;
-    // Let's skip empty strings
-    if (scope) {
-      var role = _.cloneDeep(this.state.role);
-      role.scopes.push(scope);
-      this.refs.newScope.getDOMNode().value = "";
-      this.setState({role});
-    }
-  },
-
-  /** Remove a scope from state */
-  removeScope(index) {
+  scopesUpdated(scopes) {
     var role = _.cloneDeep(this.state.role);
-    role.scopes.splice(index, 1);
-    this.setState({role });
-  },
-
-  /** Render a list of scopes */
-  renderScopes(scopes) {
-    scopes.sort();
-    return (
-      <ul className="form-control-static" style={{paddingLeft: 20}}>
-        {
-          scopes.map(function(scope, index) {
-            return <li key={index}><code>{scope}</code></li>;
-          })
-        }
-      </ul>
-    );
+    role.scopes = scopes;
+    this.setState({role});
   },
 
   /** Start editing */

--- a/lib/ui/scopeeditor.jsx
+++ b/lib/ui/scopeeditor.jsx
@@ -1,0 +1,111 @@
+var React           = require('react');
+var bs              = require('react-bootstrap');
+var _               = require('lodash');
+
+var ScopeEditor = React.createClass({
+  propTypes: {
+    // true to display the editor; expandedScopes can just display
+    // by leaving this unset
+    editing:        React.PropTypes.bool,
+    scopes:         React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+    // called when scopes have changed
+    scopesUpdated:  React.PropTypes.func,
+  },
+
+  render() {
+    try {
+      if (this.props.editing) {
+        return this.renderScopeEditor();
+      } else {
+        return this.renderScopes();
+      }
+    } catch(e) {
+      console.log(e);
+      return <span>uhoh</span>;
+    }
+  },
+
+  /** Render scopes and associated editor */
+  renderScopeEditor() {
+    var scopes = _.clone(this.props.scopes);
+    scopes.sort();
+    return (
+      <div className="form-control-static">
+        <ul style={{paddingLeft: 20}}>
+          {
+            scopes.map((scope, index) => {
+              return (
+                <li key={index}>
+                  <code>{scope}</code>
+                  &nbsp;
+                  <bs.Button
+                    className="role-editor-remove-scope-btn"
+                    bsStyle="danger"
+                    bsSize="xsmall"
+                    onClick={this.removeScope.bind(this, index)}>
+                    <bs.Glyphicon glyph="trash"/>
+                  </bs.Button>
+                </li>
+              );
+            }, this)
+          }
+        </ul>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="new-scope:for-something:*"
+            ref="newScope"/>
+          <span className="input-group-btn">
+            <button className="btn btn-success"
+                    type="button" onClick={this.addScope}>
+              <bs.Glyphicon glyph="plus"/>
+              &nbsp;
+              Add
+            </button>
+          </span>
+        </div>
+      </div>
+    );
+  },
+
+  /** Add scope to state */
+  addScope() {
+    var scope = this.refs.newScope.getDOMNode().value;
+    // Let's skip empty strings
+    if (scope) {
+      var scopes = _.clone(this.props.scopes);
+      if (scopes.indexOf(scope) == -1) {
+        scopes.push(scope);
+        scopes.sort();
+        this.props.scopesUpdated(scopes);
+      }
+      this.refs.newScope.getDOMNode().value = "";
+    }
+  },
+
+  /** Remove a scope from state */
+  removeScope(index) {
+    var scopes = _.clone(this.props.scopes);
+    scopes.splice(index, 1);
+    this.props.scopesUpdated(scopes);
+  },
+
+  /** Render a list of scopes */
+  renderScopes() {
+    var scopes = _.clone(this.props.scopes);
+    scopes.sort();
+    return (
+      <ul className="form-control-static" style={{paddingLeft: 20}}>
+        {
+          scopes.map(function(scope, index) {
+            return <li key={index}><code>{scope}</code></li>;
+          })
+        }
+      </ul>
+    );
+  },
+
+})
+
+module.exports = ScopeEditor;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "slugid":                           "^1.1.0",
     "moment":                           "2.9.0",
     "marked":                           "0.3.2",
-    "taskcluster-client":               "0.23.6",
+    "taskcluster-client":               "0.23.9",
     "react-bootstrap":                  "0.13.1",
     "jquery":                           "2.1.3",
     "react":                            "0.12.2",


### PR DESCRIPTION
This adds the ability to edit a client's scopes, factoring out the common code from roles.

It also adds enable/disable buttons, mostly so I could test the functionality.  I'm actually not sure these are a good idea, since that functionality should only be used by identity providers -- do you think I should remove the buttons?