### PR TITLE
Remove stray '$' in run locally

### DIFF
--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -390,7 +390,7 @@ var TaskInfo = React.createClass({
       var command = payload.command.map(cmd => {
         cmd = cmd.replace(/\\/g, "\\\\");
         if (/['\n\r\t\v\b]/.test(cmd)) {
-          return "$'" + cmd.replace(/['\n\r\t\v\b]/g, c => {
+          return "'" + cmd.replace(/['\n\r\t\v\b]/g, c => {
             return {
               "'":  "\\'",
               "\n": "\\n",


### PR DESCRIPTION
Hopefully this does what it says on the tin. Running locally it appears to work and `npm run test` is green.

[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1218747)