### PR TITLE
Fix some retrigger button issues

### DIFF
--- a/lib/ui/retrigger-button.jsx
+++ b/lib/ui/retrigger-button.jsx
@@ -57,7 +57,6 @@ let RetriggerButton = React.createClass({
         <code>taskId</code>.<br/><br/>
         The new task will be altered as to:
         <ul>
-          <li>Strip <code>task.routes</code> to avoid side-effects, and</li>
           <li>Update deadlines and other timestamps for the current time.</li>
         </ul>
         Note: this may not work with all tasks.
@@ -68,8 +67,6 @@ let RetriggerButton = React.createClass({
   async createTask() {
     let taskId = slugid.nice();
     let task = _.cloneDeep(this.props.task);
-
-    delete task.routes;
 
     let now = Date.now();
     let created = Date.parse(task.created);

--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -119,19 +119,10 @@ var TaskInfo = React.createClass({
             if this task is part of a continous integration process scheduling
             this task may cause your code to land with broken tests.
           </ConfirmAction>&nbsp;
-          <ConfirmAction buttonSize="xsmall"
-                         buttonStyle="success"
-                         disabled={!isResolved}
-                         glyph="repeat"
-                         label="Rerun Task"
-                         action={this.rerunTask}
-                         success="Successfully scheduled task rerun!">
-            Are you sure you wish to rerun this task?
-            This will cause a new run of the task to be created. It will only
-            succeed if the task hasn't passed it's deadline. Notice that this
-            may interfere with listeners who only expects this tasks to be
-            resolved once.
-          </ConfirmAction>&nbsp;
+          <RetriggerButton task={this.state.task}
+                        taskId={status.taskId}
+                        buttonStyle="success"
+                        buttonSize="xsmall"/>&nbsp;
           <ConfirmAction buttonSize="xsmall"
                          buttonStyle="danger"
                          disabled={isResolved}
@@ -243,10 +234,6 @@ var TaskInfo = React.createClass({
             Note that you may also not have the scopes required to create the
             resulting task.
           </ConfirmAction>&nbsp;
-          <RetriggerButton task={this.state.task}
-                        taskId={status.taskId}
-                        buttonStyle="default"
-                        buttonSize="small"/>&nbsp;
           <LoanerButton task={this.state.task}
                         taskId={status.taskId}
                         buttonStyle="default"


### PR DESCRIPTION
This fixes a couple of things that were wrong with the initial change for retrigger button stuff.

Most importantly: It now no longer strips routes.

This _does not_ fix permissions issues. That will be fixed in a temporary way for now and a longer-term fix will be found later.