### PR TITLE
Bug #1252981: Move tools.tc and github refs to HTTPS

### DIFF
--- a/hooks/hookeditor.jsx
+++ b/hooks/hookeditor.jsx
@@ -35,7 +35,7 @@ var initialHook = {
       name:             "Hook Task",
       description:      "Task Description",
       owner:            "name@example.com",
-      source:           "http://tools.taskcluster.net/hooks/"
+      source:           "https://tools.taskcluster.net/hooks/"
     }
   }
 };

--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -358,7 +358,7 @@ var TaskInfo = React.createClass({
       cmds.push("# has the correct devices configured.");
       cmds.push("# Consult the vagrant.sh file in the docker-worker repo ");
       cmds.push("# for more information on how to install and configure ");
-      cmds.push("# the loopback devices. http://www.github.com/taskcluster/docker-worker");
+      cmds.push("# the loopback devices. https://www.github.com/taskcluster/docker-worker");
       cmds.push("# Warning: This is entirely dependent on local setup and ");
       cmds.push("# availability of devices.");
       if (payload.capabilities.devices['loopbackVideo']) {

--- a/task-creator/app.jsx
+++ b/task-creator/app.jsx
@@ -19,7 +19,7 @@ var initialTask = {
     name:             "Example Task",
     description:      "Markdown description of **what** this task does",
     owner:            "name@example.com",
-    source:           "http://tools.taskcluster.net/task-creator/"
+    source:           "https://tools.taskcluster.net/task-creator/"
   }
 };
 


### PR DESCRIPTION
Note: I don't fully understand the potential impacts of this.  My hope is that this is mostly meta-data for users, but consider this a fair warning to make sure this isn't going to break something.