### PR TITLE
Ignore .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /node_modules/
+*.swp


### PR DESCRIPTION
.swp files are temporarily generate by Vim when editing a file.
We should be listing these files under git status.