### PR TITLE
click on a row in the task graph

### DIFF
--- a/task-graph-inspector/taskgraphinspector.less
+++ b/task-graph-inspector/taskgraphinspector.less
@@ -1,6 +1,16 @@
 @import "../lib/ui/taskview.less";
 
 .task-graph-inspector-tasks > tbody > tr:not(.info) {
-  cursor:         pointer;
+  cursor: pointer;
+
 }
+.table > tbody > tr > td > span.markdown-view > p:last-of-type {
+  margin: 0px;
+  
+  &:hover {
+    text-decoration: underline;
+	}
+}
+
+
 


### PR DESCRIPTION
The rows underline on hover, like a link, so users know they can click.