### PR TITLE
Remove useless whitespace in AWS provisioner

### DIFF
--- a/aws-provisioner/app.less
+++ b/aws-provisioner/app.less
@@ -1,3 +1,8 @@
 @import "workertypeeditor.less";
 
 @import "./lib/format.less";
+
+/* get rid of the silly margin on progress bars */
+.progress {
+    margin-bottom: 0px;
+}


### PR DESCRIPTION
I don't know why bootstrap includes this margin, but it's what makes every row on the AWS provisioner take up twice as much vertical space as it should..