### PR TITLE
Fix docker-exec-websocker-server to version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-keepalive":                  "0.0.1",
     "grunt-concurrent":                 "1.0.0",
     "durable-json-lint":                "0.0.1",
-    "docker-exec-websocket-server":     "^1.1.0",
+    "docker-exec-websocket-server":     "1.1.0",
     "hterm-umd":                        "^1.0.1",
     "react-treeview":                   "^0.4.2",
     "envify":                           "^3.4.0",


### PR DESCRIPTION
This should hopefully fix the broken CI. :)

See https://github.com/taskcluster/taskcluster-tools/pull/88#issuecomment-209037925