### PR TITLE
Bug 1261910: use listWorkerTypeSummaries() and state()

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rison": "^0.1.1",
     "shell-escape": "^0.2.0",
     "slugid": "^1.1.0",
-    "taskcluster-client": "^0.23.16",
+    "taskcluster-client": "^0.23.17",
     "term.js": "0.0.4",
     "www-authenticate": "^0.6.2"
   },


### PR DESCRIPTION
The `listWorkerTypeSummaries()` endpoint does not require
authentication, so this means that the site is visible even to those who
are not logged in.

As added bonuses:

 * the table renders immediately when `listWorkerTypeSummaries()`
   returns, much sooner than in older versions; pending counts are
   filled in as they arrive
 * the table's summary is updated whenver a workerType's details are
   loaded.