### PR TITLE
Bug 1272110 - Run taskcluster-interactive-shell.sh from $HOME

### DIFF
--- a/shell/app.jsx
+++ b/shell/app.jsx
@@ -34,7 +34,7 @@ $(function () {
           'if [ -z `which "$SHELL"` ]; then export SHELL="/.taskclusterutils/busybox sh"; fi;',
           'SPAWN="$SHELL";',
           'if [ "$SHELL" = "bash" ]; then SPAWN="bash -li"; fi;',
-          'if [ -f "/etc/taskcluster-interactive-shell.sh" ]; then SPAWN="/etc/taskcluster-interactive-shell.sh"; fi;',
+          'if [ -f "$HOME/taskcluster-interactive-shell.sh" ]; then SPAWN="$HOME/taskcluster-interactive-shell.sh"; fi;',
           'exec $SPAWN;'
         ].join('')
       ]


### PR DESCRIPTION
Currently there is a Permission Denied error when trying to run /etc/taskcluster-interactive-shell.sh. Moving it to the $HOME directory instead seems like the simplest solution.