### PR TITLE
Fix link for dependencies in task info view

### DIFF
--- a/lib/ui/taskinfo.jsx
+++ b/lib/ui/taskinfo.jsx
@@ -187,7 +187,7 @@ var TaskInfo = React.createClass({
               <ul>
                 {
                   task.dependencies.sort().map((dep, index) =>
-                    <li key={index}><a href="../task-inspector/#{dep}">{dep}</a></li>)
+                    <li key={index}><a href={'../task-inspector/#' + dep}>{dep}</a></li>)
                 }
               </ul>
             </dd>


### PR DESCRIPTION
The referral link under Dependencies in a task info view will direct you to an invalid url. This should fix the broken link.