### PR TITLE
better formated errors

### DIFF
--- a/lib/format.jsx
+++ b/lib/format.jsx
@@ -182,3 +182,43 @@ var Code = React.createClass({
 exports.Code = Code;
 
 
+/** Simple collapsible section */
+var Collapse = React.createClass({
+  propTypes: {
+    title:            React.PropTypes.node.isRequired,
+    children:         React.PropTypes.node.isRequired,
+    initialExpanded:  React.PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      initialExpanded: false,
+    };
+  },
+
+  getInitialState() {
+    return {
+      expanded: this.props.initialExpanded,
+    };
+  },
+
+  render() {
+    return (
+      <div>
+        <span onClick={this.toggle}>{this.props.title}</span>
+        {
+          this.state.expanded ?
+            <div>{this.props.children}</div>
+          :
+            ''
+        }
+      </div>
+    );
+  },
+
+  toggle() {
+    this.setState({expanded: !this.state.expanded});
+  },
+});
+
+exports.Collapse = Collapse;

--- a/lib/utils.jsx
+++ b/lib/utils.jsx
@@ -285,25 +285,28 @@ var createTaskClusterMixin = (options) => {
      * taskcluster-client
      */
     renderError(err) {
-      var body = undefined;
-      if (err.body) {
-        body = (
-          <pre>
-            {JSON.stringify(err.body, null, 2)}
-          </pre>
-        );
+      // Find some sort of summary or error code
+      let code = err.code + ' Error!';
+      if (!err.code && err.statusCode) {
+        code = 'HTTP ' + err.statusCode;
       }
-      var code = undefined;
-      if (err.statusCode) {
-        code = err.statusCode + ': ';
-      }
+      code = code || 'Unknown Error';
+
+      // Find some sort of message
+      let message = err.message || '```\n' + err.stack + '\n```';
+
+      let title = <bs.Button bsStyle="link">Additional details...</bs.Button>;
       return (
         <bs.Alert bsStyle="danger">
           <strong>
             {code}&nbsp;
-            {err.message || 'Unknown Error'}
           </strong>
-          {body}
+          <format.Markdown>{message}</format.Markdown>
+          <format.Collapse title={title}>
+            <pre>
+              {JSON.stringify(err.body, null, 2)}
+            </pre>
+          </format.Collapse>
         </bs.Alert>
       );
     },


### PR DESCRIPTION
I tried this in task-creator... and we still need to improve our error messages:
https://cdn.img42.com/7163800b69a4385af1f7fffd38090631.png

But this is a decent start... Just sad out error messages aren't all good markdown yet...

Anyways, I guess it's better than what we had before...