### PR TITLE
Bug 1284617 - new live log viewer doesn't break lines as well as the old one

### DIFF
--- a/lib/ui/log-fetcher.js
+++ b/lib/ui/log-fetcher.js
@@ -9,14 +9,14 @@ module.exports = function (self) {
     let matcher = /.{1,139}/g;
 
     return data
-      .split('\n')
+      .split(/\n|\[K|\[[0-9]B|\[[1-9][0-9]B/)
       .reduce((arr, line) => {
-        if (line.length < 140 || tester.test(line)) {
+        if (line.length < 140 || line.match(tester)) {
           arr.push(line);
         } else {
           arr.push(...line.match(matcher));
         }
-
+        
         return arr;
       }, []);
   }
@@ -68,3 +68,4 @@ module.exports = function (self) {
     } 
   });
  };
+ 

--- a/lib/ui/terminalview.jsx
+++ b/lib/ui/terminalview.jsx
@@ -19,7 +19,7 @@ var TerminalView = React.createClass({
   getDefaultProps() {
     return {
       url:            undefined,  // No URL to display at this point
-      rows: 40,
+      rows: 32,
       scrollDown: false,
     };
   },
@@ -167,20 +167,22 @@ var TerminalView = React.createClass({
     if (start < 0) {
       start = 0;
     }
-    var paddingRows = 0;
-    //Check if the log has less lines than the number of rows or if we are displaying the beggining of the log
-    if (this.props.rows <= this.state.lines.length && this.state.lines[start] !== this.state.lines[0]) {
-      paddingRows = 15;
-    }
-    var frame = this.state.lines.slice(start + paddingRows, start + this.props.rows + paddingRows);
+    var frame = this.state.lines.slice(start, start + this.props.rows);
     return <div className="viewer" onWheel={this.onMouseWheel}>
       <div className="buffer" ref="buffer">
       {
         frame.map(function(line) {
           // Check if there are any ansi colors/styles
+          var doubleSpace = line.match(/  /g);
           if (ansiRegex().test(line)) {
-            var new_line = ansi_up.ansi_to_html(line);
-            return <div key={start++} dangerouslySetInnerHTML={{__html: new_line}}></div>;
+            var newLine = ansi_up.ansi_to_html(line);
+            if (doubleSpace && doubleSpace.length > 0) {
+              return <div className="pre-white" key={start++} dangerouslySetInnerHTML={{__html: newLine}}></div>;
+            } else {
+              return <div key={start++} dangerouslySetInnerHTML={{__html: newLine}}></div>;
+            }
+          } else if (doubleSpace && doubleSpace.length > 0) {
+              return <div className="pre-white" key={start++}>{(line)}</div>;
           } else {
             return <div key={start++}>{(line)}</div>;
           };

--- a/lib/ui/terminalview.less
+++ b/lib/ui/terminalview.less
@@ -30,3 +30,8 @@
   width: 20px;
   background-color: #7f7f7f;
 }
+
+.pre-white {
+  white-space: pre-wrap;
+}
+


### PR DESCRIPTION
Added support for progress tables and more ways to break lines in log viewer.
Tested with:

https://tools.taskcluster.net/task-graph-inspector/#K0Fihhx4SNurUEEQrx8zZw/Hc0RyZgsRNGA2hQ2kle4Gw/0
https://tools.taskcluster.net/task-graph-inspector/#K0Fihhx4SNurUEEQrx8zZw/dWW6AGkFRa-oYpgYezfYMg/0
https://tools.taskcluster.net/task-inspector/#bNtU135dR3SqROzO-ZBa3Q/0