### PR TITLE
Swapping markdown library

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ var COMMON_MODULES = [
   'slugid',
   'debug',
   'lodash',
-  'marked',
+  'markdown-it',
   'moment',
   'rison',
   // global modules too

--- a/lib/format.jsx
+++ b/lib/format.jsx
@@ -1,7 +1,7 @@
 let React         = require('react');
 let debug         = require('debug')('lib:utils');
 let assert        = require('assert');
-let marked        = require('marked');
+let markdown      = require('markdown-it');
 let bs            = require('react-bootstrap');
 let moment        = require('moment');
 let hljs          = require('highlight.js');
@@ -56,30 +56,19 @@ exports.Icon = Icon;
 
 /** Render Markdown and handle all the particularities */
 var Markdown = React.createClass({
-  /** Validate properties */
   propTypes: {
-    children:   React.PropTypes.string,
-    safe:       React.PropTypes.bool,
-    gfm:        React.PropTypes.bool
-  },
-
-  /** Get default properties */
-  getDefaultProperties() {
-    return {
-      safe:     true,
-      gfm:      true,
-      children: ''
-    };
+    children:   React.PropTypes.string
   },
 
   /** Render Markdown */
   render() {
-    var html = marked(this.props.children || '', {
-      sanitize:     this.props.safe,
-      gfm:          this.props.gfm
-    });
-    return <span className="markdown-view"
-                 dangerouslySetInnerHTML={{__html: html}}></span>
+    const html = markdown().render(this.props.children || '');
+
+    return (
+      <span
+        className="markdown-view"
+        dangerouslySetInnerHTML={{__html: html}} />
+    );
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "url": "https://github.com/taskcluster/taskcluster-tools.git"
   },
   "dependencies": {
-    "assume": "^1.4.1",
     "ansi-regex": "^2.0.0",
     "ansi_up": "^1.3.0",
+    "assume": "^1.4.1",
     "babel-plugin-object-assign": "1.2.1",
     "babelify": "6.0.2",
     "bluebird": "^3.4.0",
@@ -46,7 +46,7 @@
     "hterm-umd": "^1.0.1",
     "jquery": "^2.2.0",
     "lodash": "^4.1.0",
-    "marked": "^0.3.5",
+    "markdown-it": "7.0.0",
     "moment": "^2.11.1",
     "promise": "^7.1.1",
     "quiet-grunt": "0.2.3",


### PR DESCRIPTION
Swapped the Markdown library. I can confirm that Markdown containing data URIs renders as plain text, and safe URLs render rich.