### PR TITLE
Bug 1286979 - Add a way to trigger a hook from web interface

### DIFF
--- a/hooks/hookeditor.jsx
+++ b/hooks/hookeditor.jsx
@@ -185,10 +185,8 @@ var HookDisplay = React.createClass({
           onClick={this.props.startEditing}>
           <bs.Glyphicon glyph="pencil"/>&nbsp;Edit Hook
         </bs.Button>
-        <bs.Button bsStyle="success"
-                   onClick={this.props.triggerHook}>
-          <bs.Glyphicon glyph="repeat"/>
-          &nbsp;Trigger Hook
+        <bs.Button bsStyle="success" onClick={this.props.triggerHook}>
+          <bs.Glyphicon glyph="repeat" /> Trigger Hook
         </bs.Button>
       </bs.ButtonToolbar>
     </div>
@@ -618,14 +616,10 @@ var HookEditView = React.createClass({
   },
 
   triggerHook() {
-    this.hooks.triggerHook(
-        this.props.currentHookGroupId,
-        this.props.currentHookId,
-        {}  // Payloads are ignored, so we send empty data over
-    ).catch(function (err) {
-          this.setState({error: err});
-        }.bind(this)
-    );
+    // Payloads are ignored, so we send empty data over
+    this.hooks
+      .triggerHook(this.props.currentHookGroupId, this.props.currentHookId, {})
+      .catch((error) => this.setState({ error }));
   },
 
   createHook(hookGroupId, hookId, hook) {

--- a/hooks/hookeditor.jsx
+++ b/hooks/hookeditor.jsx
@@ -185,6 +185,11 @@ var HookDisplay = React.createClass({
           onClick={this.props.startEditing}>
           <bs.Glyphicon glyph="pencil"/>&nbsp;Edit Hook
         </bs.Button>
+        <bs.Button bsStyle="success"
+                   onClick={this.props.triggerHook}>
+          <bs.Glyphicon glyph="repeat"/>
+          &nbsp;Trigger Hook
+        </bs.Button>
       </bs.ButtonToolbar>
     </div>
   }
@@ -533,6 +538,7 @@ var HookEditView = React.createClass({
     currentHookGroupId: React.PropTypes.string,
     refreshHookList:    React.PropTypes.func.isRequired,
     selectHook:         React.PropTypes.func.isRequired,
+    triggerHook:        React.PropTypes.func.isRequired,
   },
 
   getInitialState() {
@@ -602,12 +608,24 @@ var HookEditView = React.createClass({
         return <HookDisplay hook={this.state.hook}
                     currentHookId={this.props.currentHookId}
                     currentHookGroupId={this.props.currentHookGroupId}
-                    startEditing={this.startEditing} />
+                    startEditing={this.startEditing}
+                    triggerHook={this.triggerHook} />
     }
   },
 
   startEditing() {
     this.setState({editing: true});
+  },
+
+  triggerHook() {
+    this.hooks.triggerHook(
+        this.props.currentHookGroupId,
+        this.props.currentHookId,
+        {}  // Payloads are ignored, so we send empty data over
+    ).catch(function (err) {
+          this.setState({error: err});
+        }.bind(this)
+    );
   },
 
   createHook(hookGroupId, hookId, hook) {
@@ -633,7 +651,7 @@ var HookEditView = React.createClass({
         this.props.currentHookGroupId,
         this.props.currentHookId,
         hook
-      )
+      );
       this.setState({
         hook:    stripHookIds(hook),
         editing: false,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rison": "^0.1.1",
     "shell-escape": "^0.2.0",
     "slugid": "^1.1.0",
-    "taskcluster-client": "^0.23.17",
+    "taskcluster-client": "^1.1.0",
     "term.js": "0.0.4",
     "webworkify": "^1.2.1",
     "www-authenticate": "^0.6.2",


### PR DESCRIPTION
This pr addresses [Bug 1286979 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1286979) by adding a button to trigger a hook from the hook manager. 