### PR TITLE
Push Inspector - fix bug when large number of tasks in a taskgroupid

### DIFF
--- a/push-inspector/containers/listings.jsx
+++ b/push-inspector/containers/listings.jsx
@@ -157,7 +157,10 @@ class Listings extends Component {
     }
     
     this.setup();
-    this.constructLoopForMessages();
+    
+    if (this.props.tasksRetrievedFully && !this.loop) {
+      this.constructLoopForMessages();
+    }
   }
 
   render() {


### PR DESCRIPTION
This bug was spotted when handling a large amount of tasks in a taskGroupId. You can see the problem by inspecting the taskGroupId: **cfMDvTzETHagYx-uSPCOxQ**

The loaded list of tasks were behaving weirdly, shifting the progress bar states left and right.