### PR TITLE
Improve task-graph-inspector's UX

### DIFF
--- a/lib/ui/tasksummary.jsx
+++ b/lib/ui/tasksummary.jsx
@@ -13,26 +13,26 @@ var TaskSummary = React.createClass({
     utils.createTaskClusterMixin({
       // Need updated clients for Queue
       clients: {
-        queue:  taskcluster.Queue
+        queue: taskcluster.Queue
       },
       // Reload when props.status.taskId changes, ignore credential changes
-      reloadOnProps:  ['status.taskId'],
-      reloadOnLogin:  false
+      reloadOnProps: ['status.taskId'],
+      reloadOnLogin: false
     })
   ],
 
   // Validate properties
   propTypes: {
-    status:   React.PropTypes.object.isRequired
+    status: React.PropTypes.object.isRequired
   },
 
   /** Get initial state */
   getInitialState() {
     return {
       // task definition
-      taskLoaded:  false,
-      taskError:  null,
-      task:  undefined
+      taskLoaded: false,
+      taskError: null,
+      task: null
     };
   },
 
@@ -49,42 +49,42 @@ var TaskSummary = React.createClass({
     const { task } = this.state;
 
     var taskStateLabel = {
-      unscheduled:  'label label-default',
-      pending:  'label label-info',
-      running:  'label label-primary',
-      completed:  'label label-success',
-      failed:  'label label-danger',
-      exception:  'label label-warning'
+      unscheduled: 'label label-default',
+      pending: 'label label-info',
+      running: 'label label-primary',
+      completed: 'label label-success',
+      failed: 'label label-danger',
+      exception: 'label label-warning'
     };
 
     return this.renderWaitFor('task') || (
       <div>
-      <dl className="dl-horizontal">
-        <dt>Name</dt>
-        <dd>
-          <format.Markdown>
-            {task.metadata.name}
-          </format.Markdown>
-        </dd>
-        <dt>Description</dt>
-        <dd>
-          <format.Markdown>
-            {task.metadata.description}
-          </format.Markdown>
-        </dd>
-        <dt>State</dt>
-        <dd>
-          <span className={taskStateLabel[status.state]}>
-            {status.state}
-          </span>
-        </dd>
-        <dt>Task Inspector</dt>
-        <dd>
-          <a target="_blank" href={`../task-inspector/#${status.taskId}`}>
-            {status.taskId} <i className="fa fa-external-link" />
-          </a>
-        </dd>
-      </dl>
+        <dl className="dl-horizontal">
+          <dt>Name</dt>
+          <dd>
+            <format.Markdown>
+              {task.metadata.name}
+            </format.Markdown>
+          </dd>
+          <dt>Description</dt>
+          <dd>
+            <format.Markdown>
+              {task.metadata.description}
+            </format.Markdown>
+          </dd>
+          <dt>State</dt>
+          <dd>
+            <span className={taskStateLabel[status.state]}>
+              {status.state}
+            </span>
+          </dd>
+          <dt>Task Inspector</dt>
+          <dd>
+            <a target="_blank" href={`../task-inspector/#${status.taskId}`}>
+              {status.taskId} <i className="fa fa-external-link" />
+            </a>
+          </dd>
+        </dl>
       </div>
     );
   }

--- a/lib/ui/tasksummary.jsx
+++ b/lib/ui/tasksummary.jsx
@@ -1,10 +1,10 @@
-let React             = require('react');
-let _                 = require('lodash');
-let bs                = require('react-bootstrap');
-let format            = require('../format');
-let path              = require('path');
-let taskcluster       = require('taskcluster-client');
-let utils             = require('../utils');
+const React             = require('react');
+const _                 = require('lodash');
+const bs                = require('react-bootstrap');
+const format            = require('../format');
+const path              = require('path');
+const taskcluster       = require('taskcluster-client');
+const utils             = require('../utils');
 
 /** Displays information about a task in a tab page */
 var TaskSummary = React.createClass({
@@ -13,11 +13,11 @@ var TaskSummary = React.createClass({
     utils.createTaskClusterMixin({
       // Need updated clients for Queue
       clients: {
-        queue:                taskcluster.Queue
+        queue:  taskcluster.Queue
       },
       // Reload when props.status.taskId changes, ignore credential changes
-      reloadOnProps:          ['status.taskId'],
-      reloadOnLogin:          false
+      reloadOnProps:  ['status.taskId'],
+      reloadOnLogin:  false
     })
   ],
 
@@ -30,9 +30,9 @@ var TaskSummary = React.createClass({
   getInitialState() {
     return {
       // task definition
-      taskLoaded:         false,
-      taskError:          undefined,
-      task:               undefined
+      taskLoaded:  false,
+      taskError:  null,
+      task:  undefined
     };
   },
 
@@ -45,23 +45,17 @@ var TaskSummary = React.createClass({
 
   render() {
     // Easy references to values
-    var status  = this.props.status;
-    var task    = this.state.task;
+    const { status } = this.props;
+    const { task } = this.state;
 
     var taskStateLabel = {
-      unscheduled:      'label label-default',
-      pending:          'label label-info',
-      running:          'label label-primary',
-      completed:        'label label-success',
-      failed:           'label label-danger',
-      exception:        'label label-warning'
+      unscheduled:  'label label-default',
+      pending:  'label label-info',
+      running:  'label label-primary',
+      completed:  'label label-success',
+      failed:  'label label-danger',
+      exception:  'label label-warning'
     };
-
-    var isResolved = [
-      'completed',
-      'failed',
-      'exception'
-    ].indexOf(status.state) !== -1;
 
     return this.renderWaitFor('task') || (
       <div>
@@ -86,18 +80,14 @@ var TaskSummary = React.createClass({
         </dd>
         <dt>Task Inspector</dt>
         <dd>
-          <a target="_blank" href={'../task-inspector/#' + status.taskId}>
-            {status.taskId}
-            &nbsp;
-            <i className="fa fa-external-link"></i>
+          <a target="_blank" href={`../task-inspector/#${status.taskId}`}>
+            {status.taskId} <i className="fa fa-external-link" />
           </a>
         </dd>
       </dl>
       </div>
     );
-  },
-
+  }
 });
 
-// Export TaskSummary
 module.exports = TaskSummary;

--- a/lib/ui/tasksummary.jsx
+++ b/lib/ui/tasksummary.jsx
@@ -1,8 +1,4 @@
-let ConfirmAction     = require('./confirmaction');
-let LoanerButton      = require('./loaner-button');
-let PurgeCacheButton  = require('./purgecache-button');
 let React             = require('react');
-let RetriggerButton   = require('./retrigger-button');
 let _                 = require('lodash');
 let bs                = require('react-bootstrap');
 let format            = require('../format');
@@ -61,11 +57,11 @@ var TaskSummary = React.createClass({
       exception:        'label label-warning'
     };
 
-    // var isResolved = [
-    //   'completed',
-    //   'failed',
-    //   'exception'
-    // ].indexOf(status.state) !== -1;
+    var isResolved = [
+      'completed',
+      'failed',
+      'exception'
+    ].indexOf(status.state) !== -1;
 
     return this.renderWaitFor('task') || (
       <div>
@@ -82,93 +78,15 @@ var TaskSummary = React.createClass({
             {task.metadata.description}
           </format.Markdown>
         </dd>
-        <dt>Owner</dt>
-        <dd><code>{task.metadata.owner}</code></dd>
-        <dt>Source</dt>
-        <dd>
-          <a href={task.metadata.source}>
-            {
-              task.metadata.source.length > 90 ? (
-                <span>...{task.metadata.source.substr(8 - 90)}</span>
-              ) : (
-                <span>{task.metadata.source}</span>
-              )
-            }
-          </a>
-        </dd>
-      </dl>
-      <dl className="dl-horizontal">
         <dt>State</dt>
         <dd>
           <span className={taskStateLabel[status.state]}>
             {status.state}
           </span>
         </dd>
-        <dt>Retries Left</dt>
-        <dd>{status.retriesLeft} of {task.retries}</dd>
-      </dl>
-      <dl className="dl-horizontal">
-        <dt>Created</dt>
+        <dt>Task Inspector</dt>
         <dd>
-          <format.DateView date={task.created}/>
-        </dd>
-        <dt>Deadline</dt>
-        <dd>
-          <format.DateView date={task.deadline} since={task.created}/>
-        </dd>
-      </dl>
-      <dl className="dl-horizontal">
-        <dt>ProvisionerId</dt>
-        <dd><code>{task.provisionerId}</code></dd>
-        <dt>WorkerType</dt>
-        <dd><code>{task.workerType}</code></dd>
-      </dl>
-      <dl className="dl-horizontal">
-        <dt>SchedulerId</dt>
-        <dd><code>{task.schedulerId}</code></dd>
-        <dt>TaskGroupId</dt>
-        <dd>
-          <a href={'../task-group-inspector/#' + task.taskGroupId}>
-            {task.taskGroupId}
-          </a>
-        </dd>
-        <dt>Dependencies</dt>
-        <dd>
-          {
-            task.dependencies.length > 0 ? (
-              <ul>
-                {
-                  task.dependencies.map((dep, index) => {
-                    return (
-                      <li key={index}>
-                        <a href={'../task-inspector/#' + dep}>{dep}</a>
-                      </li>
-                    );
-                  })
-                }
-              </ul>
-            ) : (
-              '-'
-            )
-          }
-        </dd>
-        <dt>Requires</dt>
-        <dd>
-          This task will be scheduled when <i>dependencies</i> are
-          {
-            task.requires === 'all-completed' ?
-              <span> <code>all-completed</code> successfully</span>
-            :
-              <span> <code>all-resolved</code> with any resolution</span>
-          }
-          .
-        </dd>
-      </dl>
-      <dl className="dl-horizontal">
-        <dt>Task Definition</dt>
-        <dd>
-          <a href={'https://queue.taskcluster.net/v1/task/' + status.taskId}
-             target="_blank">
+          <a target="_blank" href={'../task-inspector/#' + status.taskId}>
             {status.taskId}
             &nbsp;
             <i className="fa fa-external-link"></i>

--- a/lib/ui/tasksummary.jsx
+++ b/lib/ui/tasksummary.jsx
@@ -1,0 +1,185 @@
+let ConfirmAction     = require('./confirmaction');
+let LoanerButton      = require('./loaner-button');
+let PurgeCacheButton  = require('./purgecache-button');
+let React             = require('react');
+let RetriggerButton   = require('./retrigger-button');
+let _                 = require('lodash');
+let bs                = require('react-bootstrap');
+let format            = require('../format');
+let path              = require('path');
+let taskcluster       = require('taskcluster-client');
+let utils             = require('../utils');
+
+/** Displays information about a task in a tab page */
+var TaskSummary = React.createClass({
+  mixins: [
+    // Calls load() initially and on reload()
+    utils.createTaskClusterMixin({
+      // Need updated clients for Queue
+      clients: {
+        queue:                taskcluster.Queue
+      },
+      // Reload when props.status.taskId changes, ignore credential changes
+      reloadOnProps:          ['status.taskId'],
+      reloadOnLogin:          false
+    })
+  ],
+
+  // Validate properties
+  propTypes: {
+    status:   React.PropTypes.object.isRequired
+  },
+
+  /** Get initial state */
+  getInitialState() {
+    return {
+      // task definition
+      taskLoaded:         false,
+      taskError:          undefined,
+      task:               undefined
+    };
+  },
+
+  /** Load task definition */
+  load() {
+    return {
+      task: this.queue.task(this.props.status.taskId)
+    };
+  },
+
+  render() {
+    // Easy references to values
+    var status  = this.props.status;
+    var task    = this.state.task;
+
+    var taskStateLabel = {
+      unscheduled:      'label label-default',
+      pending:          'label label-info',
+      running:          'label label-primary',
+      completed:        'label label-success',
+      failed:           'label label-danger',
+      exception:        'label label-warning'
+    };
+
+    // var isResolved = [
+    //   'completed',
+    //   'failed',
+    //   'exception'
+    // ].indexOf(status.state) !== -1;
+
+    return this.renderWaitFor('task') || (
+      <div>
+      <dl className="dl-horizontal">
+        <dt>Name</dt>
+        <dd>
+          <format.Markdown>
+            {task.metadata.name}
+          </format.Markdown>
+        </dd>
+        <dt>Description</dt>
+        <dd>
+          <format.Markdown>
+            {task.metadata.description}
+          </format.Markdown>
+        </dd>
+        <dt>Owner</dt>
+        <dd><code>{task.metadata.owner}</code></dd>
+        <dt>Source</dt>
+        <dd>
+          <a href={task.metadata.source}>
+            {
+              task.metadata.source.length > 90 ? (
+                <span>...{task.metadata.source.substr(8 - 90)}</span>
+              ) : (
+                <span>{task.metadata.source}</span>
+              )
+            }
+          </a>
+        </dd>
+      </dl>
+      <dl className="dl-horizontal">
+        <dt>State</dt>
+        <dd>
+          <span className={taskStateLabel[status.state]}>
+            {status.state}
+          </span>
+        </dd>
+        <dt>Retries Left</dt>
+        <dd>{status.retriesLeft} of {task.retries}</dd>
+      </dl>
+      <dl className="dl-horizontal">
+        <dt>Created</dt>
+        <dd>
+          <format.DateView date={task.created}/>
+        </dd>
+        <dt>Deadline</dt>
+        <dd>
+          <format.DateView date={task.deadline} since={task.created}/>
+        </dd>
+      </dl>
+      <dl className="dl-horizontal">
+        <dt>ProvisionerId</dt>
+        <dd><code>{task.provisionerId}</code></dd>
+        <dt>WorkerType</dt>
+        <dd><code>{task.workerType}</code></dd>
+      </dl>
+      <dl className="dl-horizontal">
+        <dt>SchedulerId</dt>
+        <dd><code>{task.schedulerId}</code></dd>
+        <dt>TaskGroupId</dt>
+        <dd>
+          <a href={'../task-group-inspector/#' + task.taskGroupId}>
+            {task.taskGroupId}
+          </a>
+        </dd>
+        <dt>Dependencies</dt>
+        <dd>
+          {
+            task.dependencies.length > 0 ? (
+              <ul>
+                {
+                  task.dependencies.map((dep, index) => {
+                    return (
+                      <li key={index}>
+                        <a href={'../task-inspector/#' + dep}>{dep}</a>
+                      </li>
+                    );
+                  })
+                }
+              </ul>
+            ) : (
+              '-'
+            )
+          }
+        </dd>
+        <dt>Requires</dt>
+        <dd>
+          This task will be scheduled when <i>dependencies</i> are
+          {
+            task.requires === 'all-completed' ?
+              <span> <code>all-completed</code> successfully</span>
+            :
+              <span> <code>all-resolved</code> with any resolution</span>
+          }
+          .
+        </dd>
+      </dl>
+      <dl className="dl-horizontal">
+        <dt>Task Definition</dt>
+        <dd>
+          <a href={'https://queue.taskcluster.net/v1/task/' + status.taskId}
+             target="_blank">
+            {status.taskId}
+            &nbsp;
+            <i className="fa fa-external-link"></i>
+          </a>
+        </dd>
+      </dl>
+      </div>
+    );
+  },
+
+});
+
+// Export TaskSummary
+module.exports = TaskSummary;

--- a/task-graph-inspector/taskgraphinspector.jsx
+++ b/task-graph-inspector/taskgraphinspector.jsx
@@ -47,7 +47,7 @@ var TaskGraphInspector = React.createClass({
       taskGraphId: '',
       taskId: null,
       taskGraphLoaded: true,
-      taskGraphError: undefined,
+      taskGraphError: null,
       taskGraph: null,
       taskGraphIdInput: ''
       // Remark we'll cache task status structures under
@@ -414,7 +414,7 @@ var TaskGraphInspector = React.createClass({
               <tr key={task.taskId}
                   className={this.state.taskId === task.taskId ? 'info' : null}
                   onClick={this.handleSelectTask.bind(this, task.taskId)}>
-                <td><bs.Glyphicon glyph={this.state.taskId === task.taskId ? "minus-sign" : "plus-sign"} /></td>  
+                <td><bs.Glyphicon glyph={this.state.taskId === task.taskId ? 'chevron-down' : 'chevron-right'} /></td>  
                 <td><code>{task.taskId}</code></td>
                 <td>
                   {this.state.taskId === task.taskId ?

--- a/task-graph-inspector/taskgraphinspector.jsx
+++ b/task-graph-inspector/taskgraphinspector.jsx
@@ -3,8 +3,7 @@ var bs              = require('react-bootstrap');
 var utils           = require('../lib/utils');
 var taskcluster     = require('taskcluster-client');
 var _               = require('lodash');
-var TaskView        = require('../lib/ui/taskview');
-var TaskSummary       = require('../lib/ui/tasksummary');
+var TaskSummary     = require('../lib/ui/tasksummary');
 var format          = require('../lib/format');
 var PreviousTasks   = require('../lib/ui/previoustasks');
 
@@ -15,42 +14,42 @@ var TaskGraphInspector = React.createClass({
     utils.createTaskClusterMixin({
       // Need updated clients for Queue, Scheduler and associated events
       clients: {
-        scheduler:                taskcluster.Scheduler,
-        schedulerEvents:          taskcluster.SchedulerEvents,
-        queue:                    taskcluster.Queue,
-        queueEvents:              taskcluster.QueueEvents
+        scheduler: taskcluster.Scheduler,
+        schedulerEvents: taskcluster.SchedulerEvents,
+        queue: taskcluster.Queue,
+        queueEvents: taskcluster.QueueEvents
       },
       // Reload when state.taskGraphId changes, ignore credential changes
-      reloadOnKeys:               ['taskGraphId'],
-      reloadOnLogin:              false
+      reloadOnKeys: ['taskGraphId'],
+      reloadOnLogin: false
     }),
     // Called handler when state.taskGraphId and state.taskId changes
     utils.createWatchStateMixin({
       onKeys: {
-        updateTaskGraphIdInput:   ['taskGraphId'],
-        loadTaskStatus:           ['taskId']
+        updateTaskGraphIdInput: ['taskGraphId'],
+        loadTaskStatus: ['taskId']
       }
     }),
     // Listen for messages, reload bindings() when state.taskGraphId changes
     utils.createWebListenerMixin({
-      reloadOnKeys:               ['taskGraphId']
+      reloadOnKeys: ['taskGraphId']
     }),
     // Serialize state.taskGraphId to location.hash as string
     utils.createLocationHashMixin({
-      keys:                       ['taskGraphId', 'taskId'],
-      type:                       'string'
+      keys: ['taskGraphId', 'taskId'],
+      type: 'string'
     })
   ],
 
   /** Get initial state */
   getInitialState: function() {
     return {
-      taskGraphId:        '',
-      taskId:             null,
-      taskGraphLoaded:    true,
-      taskGraphError:     undefined,
-      taskGraph:          null,
-      taskGraphIdInput:   ''
+      taskGraphId: '',
+      taskId: null,
+      taskGraphLoaded: true,
+      taskGraphError: undefined,
+      taskGraph: null,
+      taskGraphIdInput: ''
       // Remark we'll cache task status structures under
       // 'task/<taskId>/status' as arrive from messages or when we load a
       // a task...
@@ -62,14 +61,14 @@ var TaskGraphInspector = React.createClass({
     // Skip loading empty-strings
     if (this.state.taskGraphId === '') {
       return {
-        taskGraph:      null
+        taskGraph: null
       };
     }
 
     // Construct promised state
     return {
       // Load task status and take the `status` key from the response
-      taskGraph:        this.scheduler.inspect(this.state.taskGraphId)
+      taskGraph: this.scheduler.inspect(this.state.taskGraphId)
     };
   },
 
@@ -183,7 +182,7 @@ var TaskGraphInspector = React.createClass({
 
     // Create updated state
     var state = {
-      taskGraph:      taskGraph
+      taskGraph: taskGraph
     };
 
     // Cache status structure, we don't have to reload it if we select the task
@@ -293,9 +292,9 @@ var TaskGraphInspector = React.createClass({
 
     // Mapping from state to labels
     var taskGraphStateLabel = {
-      running:          'label label-primary',
-      finished:         'label label-success',
-      blocked:          'label label-danger'
+      running: 'label label-primary',
+      finished: 'label label-success',
+      blocked: 'label label-danger'
     };
 
     // Shorten source if necessary
@@ -363,13 +362,13 @@ var TaskGraphInspector = React.createClass({
   /** Render table of tasks in a task-graph */
   renderTaskTable: function() {
     var taskStateLabel = {
-      unscheduled:      'label label-default',
-      scheduled:        'label label-info',
-      pending:          'label label-info',
-      running:          'label label-primary',
-      completed:        'label label-success',
-      failed:           'label label-danger',
-      exception:        'label label-warning'
+      unscheduled: 'label label-default',
+      scheduled: 'label label-info',
+      pending: 'label label-info',
+      running: 'label label-primary',
+      completed: 'label label-success',
+      failed: 'label label-danger',
+      exception: 'label label-warning'
     };
 
     var requiredTasks = [];
@@ -413,18 +412,14 @@ var TaskGraphInspector = React.createClass({
             }
             return (
               <tr key={task.taskId}
-                  className={this.state.taskId == task.taskId ? 'info' : null}
+                  className={this.state.taskId === task.taskId ? 'info' : null}
                   onClick={this.handleSelectTask.bind(this, task.taskId)}>
-                <td><bs.Glyphicon glyph={this.state.taskId == task.taskId ? "minus-sign" : "plus-sign"} />&nbsp;</td>  
+                <td><bs.Glyphicon glyph={this.state.taskId === task.taskId ? "minus-sign" : "plus-sign"} /></td>  
                 <td><code>{task.taskId}</code></td>
                 <td>
-                  {
-                    this.state.taskId == task.taskId ?
-                      this.renderTaskSummary()
-                    :
-                    <format.Markdown>
-                      {task.name}
-                    </format.Markdown>
+                  {this.state.taskId === task.taskId ?
+                    this.renderTaskSummary() :
+                    <format.Markdown>{task.name}</format.Markdown>
                   } 
                 </td>
                 <td>
@@ -472,25 +467,19 @@ var TaskGraphInspector = React.createClass({
     // Find status structure from state
     var status = this.state['task/' + this.state.taskId + '/status'];
 
-    return (
-      <TaskSummary status={status}/>
-    );
+    return <TaskSummary status={status} />;
   },
 
   /** Update TaskGraphIdInput to reflect input */
   handleTaskGraphIdInputChange: function() {
     this.setState({
-      taskGraphIdInput:   this.refs.taskGraphId.getInputDOMNode().value.trim()
+      taskGraphIdInput: this.refs.taskGraphId.getInputDOMNode().value.trim()
     });
   },
 
   /** Handle selection of a task */
   handleSelectTask: function(taskId) {
-    if (this.state.taskId === taskId) {
-      this.setState({taskId: null});
-    } else {
-      this.setState({taskId: taskId});
-    }
+    this.setState({ taskId: this.state.taskId === taskId ? null : taskId });
   },
 
   /** Handle form submission */

--- a/task-graph-inspector/taskgraphinspector.jsx
+++ b/task-graph-inspector/taskgraphinspector.jsx
@@ -4,6 +4,7 @@ var utils           = require('../lib/utils');
 var taskcluster     = require('taskcluster-client');
 var _               = require('lodash');
 var TaskView        = require('../lib/ui/taskview');
+var TaskSummary       = require('../lib/ui/tasksummary');
 var format          = require('../lib/format');
 var PreviousTasks   = require('../lib/ui/previoustasks');
 
@@ -411,15 +412,48 @@ var TaskGraphInspector = React.createClass({
             if (task.taskId == this.state.taskId) {
               relation = '-';
             }
+            // var myStatus = this.state['task/' + task.taskId + '/status'];
+            var myStatus = {
+              "taskId": "-9J6gFkvSiGfzvvIdnjQLw",
+              "provisionerId": "aws-provisioner-v1",
+              "workerType": "opt-linux64",
+              "schedulerId": "task-graph-scheduler",
+              "taskGroupId": "RzZ5FBeISiCaLboJcS1SBg",
+              "deadline": "2016-03-04T01:59:27.255Z",
+              "expires": "3016-02-29T01:59:27.295Z",
+              "retriesLeft": 5,
+              "state": "completed",
+              "runs": [
+                {
+                  "runId": 0,
+                  "state": "completed",
+                  "reasonCreated": "scheduled",
+                  "scheduled": "2016-02-29T02:10:51.326Z",
+                  "workerGroup": "us-east-1d",
+                  "workerId": "i-f815cc7c",
+                  "takenUntil": "2016-02-29T02:31:09.204Z",
+                  "started": "2016-02-29T02:11:09.284Z",
+                  "reasonResolved": "completed",
+                  "resolved": "2016-02-29T02:11:51.828Z"
+                }
+              ]
+            };
+            // console.log('myStatus',myStatus);
             return (
               <tr key={task.taskId}
                   className={this.state.taskId == task.taskId ? 'info' : null}
                   onClick={this.handleSelectTask.bind(this, task.taskId)}>
-                <td><code>{task.taskId}</code></td>
+                <td><bs.Glyphicon glyph={this.state.taskId == task.taskId ? "minus-sign" : "plus-sign"} />&nbsp;<code>{task.taskId}</code></td>
                 <td>
                   <format.Markdown>
                     {task.name}
                   </format.Markdown>
+                  {
+                    this.state.taskId == task.taskId ?
+                      <TaskSummary status={myStatus} />
+                    :
+                      undefined
+                  } 
                 </td>
                 <td>
                   <span className={stateLabel}>
@@ -465,6 +499,8 @@ var TaskGraphInspector = React.createClass({
 
     // Find status structure from state
     var status = this.state['task/' + this.state.taskId + '/status'];
+    console.log('task/' + this.state.taskId + '/status','status-0');
+    console.log(status,'status-1');
 
     return (
       <TaskView ref="taskView"

--- a/task-graph-inspector/taskgraphinspector.jsx
+++ b/task-graph-inspector/taskgraphinspector.jsx
@@ -356,8 +356,6 @@ var TaskGraphInspector = React.createClass({
         <dd><code>{taskGraph.status.taskGraphId}</code></dd>
       </dl>
       {this.renderTaskTable()}
-      <hr/>
-      {this.renderTaskView()}
       </span>
     );
   },
@@ -390,6 +388,7 @@ var TaskGraphInspector = React.createClass({
       <table className="table table-condensed task-graph-inspector-tasks">
         <thead>
           <tr>
+            <th>&nbsp;</th>
             <th>TaskId</th>
             <th>Name</th>
             <th>State</th>
@@ -412,47 +411,20 @@ var TaskGraphInspector = React.createClass({
             if (task.taskId == this.state.taskId) {
               relation = '-';
             }
-            // var myStatus = this.state['task/' + task.taskId + '/status'];
-            var myStatus = {
-              "taskId": "-9J6gFkvSiGfzvvIdnjQLw",
-              "provisionerId": "aws-provisioner-v1",
-              "workerType": "opt-linux64",
-              "schedulerId": "task-graph-scheduler",
-              "taskGroupId": "RzZ5FBeISiCaLboJcS1SBg",
-              "deadline": "2016-03-04T01:59:27.255Z",
-              "expires": "3016-02-29T01:59:27.295Z",
-              "retriesLeft": 5,
-              "state": "completed",
-              "runs": [
-                {
-                  "runId": 0,
-                  "state": "completed",
-                  "reasonCreated": "scheduled",
-                  "scheduled": "2016-02-29T02:10:51.326Z",
-                  "workerGroup": "us-east-1d",
-                  "workerId": "i-f815cc7c",
-                  "takenUntil": "2016-02-29T02:31:09.204Z",
-                  "started": "2016-02-29T02:11:09.284Z",
-                  "reasonResolved": "completed",
-                  "resolved": "2016-02-29T02:11:51.828Z"
-                }
-              ]
-            };
-            // console.log('myStatus',myStatus);
             return (
               <tr key={task.taskId}
                   className={this.state.taskId == task.taskId ? 'info' : null}
                   onClick={this.handleSelectTask.bind(this, task.taskId)}>
-                <td><bs.Glyphicon glyph={this.state.taskId == task.taskId ? "minus-sign" : "plus-sign"} />&nbsp;<code>{task.taskId}</code></td>
+                <td><bs.Glyphicon glyph={this.state.taskId == task.taskId ? "minus-sign" : "plus-sign"} />&nbsp;</td>  
+                <td><code>{task.taskId}</code></td>
                 <td>
-                  <format.Markdown>
-                    {task.name}
-                  </format.Markdown>
                   {
                     this.state.taskId == task.taskId ?
-                      <TaskSummary status={myStatus} />
+                      this.renderTaskSummary()
                     :
-                      undefined
+                    <format.Markdown>
+                      {task.name}
+                    </format.Markdown>
                   } 
                 </td>
                 <td>
@@ -485,8 +457,8 @@ var TaskGraphInspector = React.createClass({
     );
   },
 
-  /** Render taskview for currently selected task */
-  renderTaskView: function() {
+  /** Render taskSummary for currently selected task */
+  renderTaskSummary: function() {
     // If nothing is selected don't try to load
     if (!this.state.taskId || this.state.taskId === '') {
       return undefined;
@@ -499,14 +471,9 @@ var TaskGraphInspector = React.createClass({
 
     // Find status structure from state
     var status = this.state['task/' + this.state.taskId + '/status'];
-    console.log('task/' + this.state.taskId + '/status','status-0');
-    console.log(status,'status-1');
 
     return (
-      <TaskView ref="taskView"
-          hashEntry={this.nextHashEntry()}
-          status={status}
-          queue={this.props.queue}/>
+      <TaskSummary status={status}/>
     );
   },
 
@@ -519,7 +486,11 @@ var TaskGraphInspector = React.createClass({
 
   /** Handle selection of a task */
   handleSelectTask: function(taskId) {
-    this.setState({taskId: taskId});
+    if (this.state.taskId === taskId) {
+      this.setState({taskId: null});
+    } else {
+      this.setState({taskId: taskId});
+    }
   },
 
   /** Handle form submission */

--- a/task-graph-inspector/taskgraphinspector.less
+++ b/task-graph-inspector/taskgraphinspector.less
@@ -12,5 +12,10 @@
 	}
 }
 
+.glyphicon-plus-sign {
+	color: #5cb85c;
+}
 
-
+.glyphicon-minus-sign {
+	color: #d9534f;
+}

--- a/task-graph-inspector/taskgraphinspector.less
+++ b/task-graph-inspector/taskgraphinspector.less
@@ -1,9 +1,9 @@
 @import "../lib/ui/taskview.less";
 
-.task-graph-inspector-tasks > tbody > tr:not(.info) {
+.task-graph-inspector-tasks > tbody > tr {
   cursor: pointer;
-
 }
+
 .table > tbody > tr > td > span.markdown-view > p:last-of-type {
   margin: 0px;
   
@@ -13,9 +13,9 @@
 }
 
 .glyphicon-plus-sign {
-	color: #5cb85c;
+  color: #5cb85c;
 }
 
 .glyphicon-minus-sign {
-	color: #d9534f;
+  color: #d9534f;
 }

--- a/task-graph-inspector/taskgraphinspector.less
+++ b/task-graph-inspector/taskgraphinspector.less
@@ -11,11 +11,3 @@
     text-decoration: underline;
 	}
 }
-
-.glyphicon-plus-sign {
-  color: #5cb85c;
-}
-
-.glyphicon-minus-sign {
-  color: #d9534f;
-}


### PR DESCRIPTION
This is to cover **[Bug 1241185](https://bugzilla.mozilla.org/show_bug.cgi?id=1241185) - Make task-graph-inspector links more obviously clickable, do something visible**

@djmitche  can you please take a look at the screenshot attached and see if you would display any additional info for the selected task? 
<img width="1074" alt="screen shot 2016-08-16 at 10 54 08 am" src="https://cloud.githubusercontent.com/assets/4016496/17706124/65e3834c-63a0-11e6-8b25-f0d4dc548a5a.png">
