### PR TITLE
Make help link open in new tab

### DIFF
--- a/src/hooks/hookeditor.jsx
+++ b/src/hooks/hookeditor.jsx
@@ -309,7 +309,7 @@ const HookEditor = React.createClass({
             <label className="control-label col-md-2">Schedule</label>
             <div className="col-md-10">
                <p className="text-info">
-                 See <a href="https://www.npmjs.com/package/cron-parser">cron-parser</a> for format
+                 See <a target="_blank" href="https://www.npmjs.com/package/cron-parser">cron-parser</a> for format
                  information. Times are in UTC.
                </p>
                <ul style={{ paddingLeft: 20 }}>


### PR DESCRIPTION
I haven't tested this locally, but I don't think it should break anything?