### PR TITLE
Editing worker types in the provisioner UI

### DIFF
--- a/src/aws-provisioner/workertypetable.js
+++ b/src/aws-provisioner/workertypetable.js
@@ -322,7 +322,7 @@ export default React.createClass({
                   provisionerId={this.props.provisionerId}
                   workerType={workerType}
                   selected={this.state.selected === workerType.workerType}
-                  onClick={() => this.setSelected(this.workerType.workerType)}
+                  onClick={() => this.setSelected(workerType.workerType)}
                   summary={workerType} />
               ))
           }


### PR DESCRIPTION
I don't seem to have sufficient scopes to edit workertypes to fully test it.

Problem:
`this.workerType.workerType` is undefined

Solution:
the map function gives access to `workerType`. No need to use `this`