### PR TITLE
Bug 1310035: display 'sign in' when credentials are expired at page load

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -45,13 +45,14 @@ export const loadCredentials = () => {
 
     if (creds.certificate && creds.certificate.expiry < Date.now()) {
       saveCredentials(null); // clear credentials
-    } else if (creds.certificate) {
-      clearTimeout(credentialsExpiredTimeout);
+      return null;
+    }
 
+    clearTimeout(credentialsExpiredTimeout);
+    if (creds.certificate) {
       credentialsExpiredTimeout = setTimeout(() => saveCredentials(null),
         creds.certificate.expiry - Date.now());
     } else {
-      clearTimeout(credentialsExpiredTimeout);
       credentialsExpiredTimeout = null;
     }
 


### PR DESCRIPTION
The issue was that `loadCredentials` was, when invalidating the credentials, still returning the expired credentials.  I think that in the old implementation we were lucky enough to not call `loadCredentials` until Layout started listening for `credentials-changed`, but that has since changed and anyway is a very fragile thing to rely on.