### PR TITLE
Ignore trailing `index.html` when determining current pages.

### DIFF
--- a/src/lib/Layout.js
+++ b/src/lib/Layout.js
@@ -123,11 +123,12 @@ const Navigation = React.createClass({
   // Render navigation bar
   render() {
     // Find active menu entry
-    let activeEntry = menu.find(entry => entry.link === location.pathname) ||
+    const pathname = location.pathname.replace(/\/index.html$/, '/');
+    let activeEntry = menu.find(entry => entry.link === pathname) ||
       { title: 'Unknown Page' };
 
     // Remove title on landing page
-    if (window.location.pathname === '/') {
+    if (pathname === '/') {
       activeEntry = null;
     } else {
       const link = document.createElement('link');


### PR DESCRIPTION
It probably makes more sense to redirect to the page without `/index.html`, but if somebody ends up on a page with `/index.html`, it makes sense to correctly detect where in the application they are.