### PR TITLE
[RFC] Paramaterize base domain to allow multiple independent deployments.

### DIFF
--- a/src/lib/utils.jsx
+++ b/src/lib/utils.jsx
@@ -327,7 +327,11 @@ export const createTaskClusterMixin = opts => {
     /** Initialize client objects requested in options */
     _createClients(credentials) {
       _.forIn(options.clients, (Client, key) => {
-        this[key] = new Client({ credentials, ...options.clientOpts[key] });
+        this[key] = new Client({
+          credentials,
+          baseDomain: process.env.BASE_DOMAIN,
+          ...options.clientOpts[key]
+        });
       });
     }
   };

--- a/tools-preset/env.js
+++ b/tools-preset/env.js
@@ -1,6 +1,8 @@
 module.exports = {
   NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
 
+  BASE_DOMAIN: JSON.stringify(process.env.BASE_DOMAIN || 'taskcluster.net'),
+
   CORS_PROXY: JSON.stringify(
     process.env.CORS_PROXY || 'https://cors-proxy.taskcluster.net/request'),
 


### PR DESCRIPTION
This is a continuation of the sketch at [here](https://github.com/taskcluster/taskcluster-client/pull/60) for parameterizing the top-level domain for interacting with task-cluster.