### PR TITLE
Redirect pages with `/index.html` to the corresponding page without.

### DIFF
--- a/src/lib/Layout.js
+++ b/src/lib/Layout.js
@@ -51,6 +51,13 @@ const Navigation = React.createClass({
     this.startExpirationTimer();
   },
 
+  // Redirect to path without a trailing `/index.html`.
+  componentWillMount() {
+    if (location.pathname.endsWith('/index.html')) {
+      location.pathname = location.pathname.replace(/\/index.html$/, '/');
+    }
+  },
+
   // Stop listening for credentials-changed events
   componentWillUnmount() {
     window.removeEventListener('credentials-changed', this.handleCredentialsChanged, false);


### PR DESCRIPTION
This is an alternative to #168.

I'm not familiar enough with react to know if `componentWillMount` is the right place for this logic; the documentation suggests that state shouldn't be manipulated in it, but since this entirely replaces the page, I don't think that is a big issue. 