### PR TITLE
Upgrade `neutrino` so deploy doesn't upload on failed builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "html-webpack-plugin": "2.22.0",
     "less": "2.7.1",
     "lodash.clonedeep": "4.5.0",
-    "neutrino": "2.1.0",
+    "neutrino": "2.2.0",
     "neutrino-preset-react": "1.1.1",
     "s3-deploy": "0.6.1",
     "shebang-loader": "0.0.1",


### PR DESCRIPTION
This pulls in the fix from mozilla-neutrino/neutrino#3, which bit me several times trying to deploy an instance of this.