### PR TITLE
Add an email signin option

### DIFF
--- a/src/lib/Layout.js
+++ b/src/lib/Layout.js
@@ -10,6 +10,7 @@ import {Icon} from './format';
 import OktaMenuItem from './ui/OktaMenuItem';
 import PersonaMenuItem from './ui/PersonaMenuItem';
 import DevelopmentMenuItem from './ui/DevelopmentMenuItem';
+import EmailMenuItem from './ui/EmailMenuItem';
 import ManualMenuItem from './ui/ManualMenuItem';
 import './base-layout.less';
 
@@ -19,6 +20,7 @@ const SIGNIN_MENU_ITEMS = {
   okta: OktaMenuItem,
   persona: PersonaMenuItem,
   development: DevelopmentMenuItem,
+  email: EmailMenuItem,
   manual: ManualMenuItem,
 };
 

--- a/src/lib/ui/EmailMenuItem.js
+++ b/src/lib/ui/EmailMenuItem.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import {OverlayTrigger, Tooltip, NavItem, Glyphicon} from 'react-bootstrap';
+
+export default class extends React.Component {
+  // This authenticates with Auth0's passwordless lock by opening a new Window
+  // where Auth0 will do its thing, then closing that window once creds are
+  // acquired.
+  signIn() {
+    // Just loading this page is sufficient. It eventually redirects back to
+    // https://tools.t.n/login, which updates LocalStorage. Auth listens for
+    // such updates and loads the creds out of storage.
+    window.open('https://login.taskcluster.net/auth0/login', '_blank');
+  }
+
+  render() {
+    const tooltip = (
+      <Tooltip id="passwordless-signin">
+        If you are a Mozillian but do not have an LDAP account, sign in with
+        this option, which will require you to verify your email address, using
+        an email on your Mozillians profile.  If you do not have a Mozillians
+        profile, set one up now. Get vouched to gain access to additional
+        scopes.
+      </Tooltip>
+    );
+
+    return (
+      <OverlayTrigger placement="left" delay={600} overlay={tooltip}>
+        <NavItem onSelect={() => this.signIn()}>
+          <Glyphicon glyph="log-in" /> Sign In with Email
+        </NavItem>
+      </OverlayTrigger>
+    );
+  }
+}


### PR DESCRIPTION
This works a lot like Okta: open a new window, which will eventually
redirect to the tools site, which will update LocalStorage and close the
window.

(Note that pending https://github.com/taskcluster/taskcluster-login/pull/38 this will not automatically redirect back; I'll land that first)