### PR TITLE
Switch task group sorting to table

### DIFF
--- a/src/task-group-inspector/actions/index.js
+++ b/src/task-group-inspector/actions/index.js
@@ -89,25 +89,10 @@ export const fetchTasksInSteps = (taskGroupId, isLimited) => {
           return;
         }
 
-        const tasks = response.tasks.sort((a, b) => {
-          const nameA = a.task.metadata.name.toUpperCase();
-          const nameB = b.task.metadata.name.toUpperCase();
-
-          if (nameA < nameB) {
-            return -1;
-          }
-
-          if (nameA > nameB) {
-            return 1;
-          }
-
-          return 0;
-        });
-
         // Dispatch tasks
         dispatch({
           type: isLimited ? FETCH_TASKS_IN_STEP : FETCH_TASKS_FULLY,
-          payload: tasks,
+          payload: response.tasks,
         });
 
         // Flag to indicate whether list has been loaded

--- a/src/task-group-inspector/containers/table.jsx
+++ b/src/task-group-inspector/containers/table.jsx
@@ -41,20 +41,26 @@ class TaskTable extends Component {
           </tr>
         </thead>
         <tbody className="tasks-list-body">
-          {tasks.reduce((rows, task, key) => {
-            if (!activeTaskStatus || task.status.state === activeTaskStatus) {
-              rows.push(
-                <tr onClick={() => this.taskClicked(task)} key={key}>
-                  <td>
-                    <Label bsSize="sm" bsStyle={labels[task.status.state]}>{task.status.state}</Label>
-                  </td>
-                  <td>{task.task.metadata.name}</td>
-                </tr>
-              );
-            }
+          {
+            tasks
+              .sort((a, b) => a.task.metadata.name.localeCompare(b.task.metadata.name, {
+                sensitivity: 'base',
+              }))
+              .reduce((rows, task, key) => {
+                if (!activeTaskStatus || task.status.state === activeTaskStatus) {
+                  rows.push(
+                    <tr onClick={() => this.taskClicked(task)} key={key}>
+                      <td>
+                        <Label bsSize="sm" bsStyle={labels[task.status.state]}>{task.status.state}</Label>
+                      </td>
+                      <td>{task.task.metadata.name}</td>
+                    </tr>
+                  );
+                }
 
-            return rows;
-          }, [])}
+                return rows;
+              }, [])
+          }
         </tbody>
       </Table>
     );


### PR DESCRIPTION
The previous implementation involved sorting the response tasks, but this doesn't work with multiple responses as they are concatenated to the original array and not re-sorted. Now, we will just sort all the table entries prior to being put in the table.