### PR TITLE
Goodbye two-click loaner

### DIFF
--- a/src/lib/ui/LoanerButton.js
+++ b/src/lib/ui/LoanerButton.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import taskcluster from 'taskcluster-client';
+import ConfirmAction from './confirmaction';
+import * as utils from '../utils';
+import slugid from 'slugid';
+import _ from 'lodash';
+import {Button} from 'react-bootstrap';
+
+const LoanerButton = React.createClass({
+  mixins: [
+    utils.createTaskClusterMixin({
+      // Need updated clients for Queue
+      clients: {
+        queue: taskcluster.Queue,
+      },
+    }),
+  ],
+
+  propTypes: {
+    taskId: React.PropTypes.string.isRequired,
+    task: React.PropTypes.object.isRequired,
+    buttonSize: React.PropTypes.string.isRequired,
+    buttonStyle: React.PropTypes.string.isRequired,
+    disabled: React.PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false,
+    };
+  },
+
+  valid() {
+    const payload = this.props.task.payload;
+
+    if (!payload || !payload.image) {
+      return false;
+    }
+
+    if (!Array.isArray(payload.command)) {
+      return false;
+    }
+
+    return typeof payload.maxRunTime === 'number';
+  },
+
+  render() {
+    // These items are buttons displayed inline-block, so wrapping in a span is correct
+    return (
+      <span>
+        <Button
+          bsSize={this.props.buttonSize}
+          bsStyle={this.props.buttonStyle}
+          disabled={this.props.disabled || !this.valid()}
+          onClick={this.createTask}>One-Click Loaner
+        </Button>&nbsp;
+        <Button
+          bsSize={this.props.buttonSize}
+          bsStyle="default"
+          disabled={this.props.disabled || !this.valid()}
+          onClick={this.editTask}>
+          Edit and Create Loaner Task
+        </Button>
+      </span>
+    );
+  },
+
+  parameterizeTask() {
+    const task = _.cloneDeep(this.props.task);
+
+    // Strip taskGroupId and schedulerId
+    delete task.taskGroupId;
+    delete task.schedulerId;
+
+    // Strip routes
+    delete task.routes;
+
+    task.payload.env = task.payload.env || {};
+    task.payload.env.TASKCLUSTER_INTERACTIVE = 'true';
+
+    // Strip artifacts
+    delete task.payload.artifacts;
+
+    // Strip dependencies and requires
+    delete task.dependencies;
+    delete task.requires;
+
+    // Set interactive = true
+    task.payload.features = task.payload.features || {};
+    task.payload.features.interactive = true;
+
+    // Strip caches
+    delete task.payload.cache;
+
+    // Delete cache scopes
+    task.scopes = task.scopes.filter(scope => !/^docker-worker:cache:/.test(scope));
+
+    // Update maxRunTime
+    task.payload.maxRunTime = Math.max(
+      task.payload.maxRunTime,
+      3 * 60 * 60
+    );
+
+    // Update timestamps
+    task.deadline = taskcluster.fromNowJSON('12 hours');
+    task.created = taskcluster.fromNowJSON();
+    task.expires = taskcluster.fromNowJSON('7 days');
+
+    // Set task,retries to 0
+    task.retries = 0;
+
+    return task;
+  },
+
+  async createTask() {
+    const taskId = slugid.nice();
+    const task = this.parameterizeTask();
+
+    await this.queue.createTask(taskId, task);
+    window.location = `/one-click-loaner/connect/#${taskId}`;
+  },
+
+  editTask() {
+    const task = this.parameterizeTask();
+
+    // overwrite task-creator's local state with this new task
+    localStorage.setItem('task-creator/task', JSON.stringify(task));
+
+    // ..and go there
+    window.location.href = '/task-creator/';
+  },
+});
+
+export default LoanerButton;

--- a/src/one-click-loaner/one-click-loaner.jsx
+++ b/src/one-click-loaner/one-click-loaner.jsx
@@ -3,7 +3,7 @@ import {findDOMNode} from 'react-dom';
 import {FormGroup, FormControl, ControlLabel, InputGroup, Button} from 'react-bootstrap';
 import * as utils from '../lib/utils';
 import taskcluster from 'taskcluster-client';
-import LoanerButton from '../lib/ui/loaner-button';
+import LoanerButton from '../lib/ui/LoanerButton';
 
 const VALID_INPUT = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
 
@@ -88,18 +88,27 @@ export default React.createClass({
             </InputGroup>
           </FormGroup>
         </form>
-        <br /><br />
-        {!invalidInput && (
-          <div className="text-center">
-            {this.renderWaitFor('task') || (this.state.task && (
+        {!invalidInput && (this.renderWaitFor('task') || (this.state.task && (
+          <div>
+            This will duplicate the task and create it under a different <code>taskId</code>.
+            <br /><br />
+            The new task will be altered as to:
+            <ul>
+              <li>Set <code>task.payload.features.interactive = true</code></li>
+              <li>Strip <code>task.payload.caches</code> to avoid poisoning</li>
+              <li>Ensures <code>task.payload.maxRunTime</code> is minimum 60 minutes</li>
+              <li>Strip <code>task.routes</code> to avoid side-effects</li>
+              <li>Set the environment variable<code>TASKCLUSTER_INTERACTIVE=true</code></li>
+            </ul>
+            Note: this may not work with all tasks.
+            <div className="text-center">
               <LoanerButton
                 buttonStyle="primary"
-                buttonSize="large"
                 taskId={this.state.taskId}
                 task={this.state.task} />
-            ))}
+            </div>
           </div>
-        )}
+        )))}
       </div>
     );
   },


### PR DESCRIPTION
Right now the one-click loaner page actually requires two clicks in order to launch a loaner, which makes it a bit of a misnomer, as well as degrading UX by complicating the flow of intent. Instead of keeping the relevant information hidden in a modal, this PR puts that data on the page and jumps immediately to launching the one-click loaner when clicking the button.