### PR TITLE
Pulse Inspector UI, 'Clear Bindings' button disabled

### DIFF
--- a/src/pulse-inspector/pulseinspector.jsx
+++ b/src/pulse-inspector/pulseinspector.jsx
@@ -137,7 +137,7 @@ export default React.createClass({
               bsSize="sm"
               bsStyle="danger"
               onClick={this.clearBindings}
-              disabled={!!this.state.bindings.length}>
+              disabled={!this.state.bindings.length}>
               <Glyphicon glyph="trash" /> Clear Bindings
             </Button>
           </ButtonToolbar>


### PR DESCRIPTION
Loading https://tools.taskcluster.net/pulse-inspector/#!() in FF50.1.0, the 'Clear Bindings' button is enabled, until you add a Pulse Exchange and Routing Key Pattern. From then on, whether listening has been started or stopped, the 'Clear Bindings' button is disabled.