### PR TITLE
Strip trailing and leading spaces from scope names

### DIFF
--- a/src/lib/ui/scopeeditor.jsx
+++ b/src/lib/ui/scopeeditor.jsx
@@ -39,6 +39,7 @@ const ScopeEditor = React.createClass({
     const scopes = findDOMNode(this.refs.scopeText)
       .value
       .split(/[\r\n]+/)
+      .map(s => s.trim())
       .filter(s => s !== '');
 
     return Array.from(new Set(scopes)).sort();


### PR DESCRIPTION
This has bitten us a few times, when copy/pasting scope lists.  The
spaces are invisible when pasted.

This still allows spaces *in* a scope, just not leading or trailing
spaces.  Those are allowed in the API, just not in the UI.

@jonasfj I know we talked about this once.. but at this point I think this will prevent issues and that's more important than preventing the typing of some hypothetical scopes.  It caused a treeclosure today :(