### PR TITLE
Fix scope list flattening in scope inspector

### DIFF
--- a/src/auth/scopes/scopeinspector.jsx
+++ b/src/auth/scopes/scopeinspector.jsx
@@ -244,10 +244,10 @@ export default React.createClass({
   },
 
   renderScopes() {
-    const scopes = _.uniq(_.flatten(
+    const scopes = _.uniq(_.flattenDeep([
       this.state.roles.map(role => role.expandedScopes),
-      this.state.clients.map(client => client.expandedScopes)
-    ))
+      this.state.clients.map(client => client.expandedScopes),
+    ]))
     .sort()
     .filter(scope => _.includes(scope, this.state.scopeSearchTerm));
 


### PR DESCRIPTION
This is why we weren't seeing the full list. It was only showing the roles scopes at first.