### PR TITLE
Update date parsing to validate better

### DIFF
--- a/src/lib/ui/timeinput.jsx
+++ b/src/lib/ui/timeinput.jsx
@@ -40,8 +40,8 @@ export default React.createClass({
 
   onChange(e) {
     const value = e.target.value;
-    const parsed = moment(value);
-    const valid = parsed.format(this.props.format) === value;
+    const parsed = moment(value, this.props.format, true); // true enables strict parsing
+    const valid = parsed.isValid();
 
     this.setState({valid});
 


### PR DESCRIPTION
This fixes a bug where `2017-04-01 00:00:00 -0800` is invalid while `2017-02-01 00:00:00 -0800` is valid. I believe this happens because moment returns a slightly different value than the input where it basically changes the timezone but offsets the hour by the correct amount anyway. It's definitely strange behavior from moment, but I believe this way should work just fine.