### PR TITLE
Add tag display to task inspector

### DIFF
--- a/src/lib/ui/taskinfo.jsx
+++ b/src/lib/ui/taskinfo.jsx
@@ -132,6 +132,26 @@ const TaskInfo = React.createClass({
             </tr>
 
             <tr>
+              <td>Tags</td>
+              <td>
+                <table className="tag-table">
+                  <tr>
+                    <th>Tag</th><th>Value</th>
+                  </tr>
+                  {
+                    Object
+                      .entries(task.tags)
+                      .map(([key, value]) => (
+                        <tr key={key}>
+                          <td>{key}</td><td>{value}</td>
+                        </tr>
+                      ))
+                  }
+                </table>
+              </td>
+            </tr>
+
+            <tr>
               <td>Requires</td>
               <td>
                 This task will be scheduled when <em>dependencies</em> are

--- a/src/lib/ui/taskinfo.less
+++ b/src/lib/ui/taskinfo.less
@@ -14,4 +14,10 @@
   }
 }
 
-
+.tag-table {
+  border: 1px solid #424242;
+  td, th {
+    border: 1px solid #424242;
+    padding: 4px;
+  }
+}


### PR DESCRIPTION
The tag information is now useful for debugging some types of things
(e.g. action tasks), so let's include it in the task inspector. We'll
use the same code display that we do for the environment.