### PR TITLE
Update QuickStart commands

### DIFF
--- a/src/quickstart/YamlCreator.jsx
+++ b/src/quickstart/YamlCreator.jsx
@@ -55,27 +55,27 @@ const cmdDirectory = {
     '/bin/bash',
     '--login',
     '-c',
-    'git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && npm install . && npm test',
+    'git clone {{event.head.repo.url}} repo && cd repo && git config advice.detachedHead false && git checkout {{event.head.sha}} && npm install . && npm test',
   ],
   'rail/python-test-runner': [
     '/bin/bash',
     '--login',
     '-c',
-    'git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && python setup.py test',
+    'git clone {{event.head.repo.url}} repo && cd repo && git config advice.detachedHead false && git checkout {{event.head.sha}} && python setup.py test',
   ],
   'jimmycuadra/rust:latest': [
     '/bin/bash',
     '--login',
     '-c',
     'git clone {{event.head.repo.url}} repo && cd repo' +
-    '&& git checkout {{event.head.sha}} && rustc --test unit_test.rs && ./unit_test',
+    '&& git config advice.detachedHead false && git checkout {{event.head.sha}} && rustc --test unit_test.rs && ./unit_test',
   ],
   'golang:1.8': [
     '/bin/bash',
     '--login',
     '-c',
-    'go get -t github.com/taskcluster/taskcluster-cli/... &&' +
-    ' cd  /go/src/github.com/taskcluster/taskcluster-cli make && go test ./...',
+    'go get -t github.com/owner/repo/... &&' +
+    ' cd  /go/src/github.com/owner/repo && make && go test ./...',
   ],
 };
 


### PR DESCRIPTION
This adds `git config advice.detachedHead false` (which avoids the
detached-head warning) and also fixes up the golang command so that it
doesn't always build tc-cli.

@owlishDeveloper 