### PR TITLE
do not strip schedulerId from loaners

### DIFF
--- a/src/lib/ui/loaner-button.jsx
+++ b/src/lib/ui/loaner-button.jsx
@@ -82,9 +82,8 @@ const LoanerButton = React.createClass({
   parameterizeTask() {
     const task = _.cloneDeep(this.props.task);
 
-    // Strip taskGroupId and schedulerId
+    // Strip taskGroupId
     delete task.taskGroupId;
-    delete task.schedulerId;
 
     // Strip routes
     delete task.routes;


### PR DESCRIPTION
This breaks scopes required to create tasks.