### PR TITLE
Shrink space used for non-sense in task-inspector

### DIFF
--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -461,14 +461,6 @@ export default class Inspector extends React.PureComponent {
     return (
       <div>
         <HelmetTitle title={`${task ? task.metadata.name : 'Task Inspector'}`} />
-        <h4>Task &amp; Group Inspector</h4>
-        <p>
-          Given a task group ID or task ID, inspect task groups, monitor progress, view dependencies and states, and
-          inspect individual tasks&rsquo; state, runs, public and private artifacts, definition, and logs as they are
-          evaluated.
-        </p>
-        <hr />
-
         <Row>
           <Col xs={12}>
             <SearchForm

--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -461,6 +461,7 @@ export default class Inspector extends React.PureComponent {
     return (
       <div>
         <HelmetTitle title={`${task ? task.metadata.name : 'Task Inspector'}`} />
+        <h4>Task &amp; Group Inspector</h4>
         <Row>
           <Col xs={12}>
             <SearchForm

--- a/src/views/UnifiedInspector/SearchForm.js
+++ b/src/views/UnifiedInspector/SearchForm.js
@@ -87,13 +87,12 @@ export default class SearchForm extends React.PureComponent {
         <Col lg={5} md={5} sm={4}>
           <FormGroup validationState={valid.taskGroupId ? null : 'error'} style={{ marginRight: 0 }}>
             <InputGroup>
-              <InputGroup.Addon style={{ textAlign: 'left' }}>TaskGroupId</InputGroup.Addon>
+              <InputGroup.Addon style={{ textAlign: 'left' }}>Task Group ID</InputGroup.Addon>
               <FormControl
                 type="text"
                 placeholder="Enter a task group ID"
                 value={taskGroupIdInput}
-                onChange={this.handleTaskGroupIdInputChange}
-                style={{ fontFamily: 'monospace' }} />
+                onChange={this.handleTaskGroupIdInputChange} />
             </InputGroup>
           </FormGroup>
         </Col>
@@ -101,19 +100,18 @@ export default class SearchForm extends React.PureComponent {
         <Col lg={5} md={5} sm={4}>
           <FormGroup validationState={valid.taskId ? null : 'error'} style={{ marginRight: 0 }}>
             <InputGroup>
-              <InputGroup.Addon style={{ textAlign: 'left' }}>TaskId</InputGroup.Addon>
+              <InputGroup.Addon style={{ textAlign: 'left' }}>Task ID</InputGroup.Addon>
               <FormControl
                 type="text"
                 placeholder="Enter a task ID or choose one from Tasks"
                 value={taskIdInput}
-                onChange={this.handleTaskIdInputChange}
-                style={{ fontFamily: 'monospace' }} />
+                onChange={this.handleTaskIdInputChange} />
             </InputGroup>
           </FormGroup>
         </Col>
 
         <Col lg={2} md={2} sm={4} style={{ padding: 0 }}>
-          <ButtonGroup>
+          <ButtonGroup style={{ marginBottom: 15 }}>
             <Button
               type="submit"
               disabled={!valid.form}>

--- a/src/views/UnifiedInspector/SearchForm.js
+++ b/src/views/UnifiedInspector/SearchForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { array, func, string } from 'prop-types';
-import { Col, Form, FormGroup, InputGroup, FormControl, Button, ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
+import { Col, Form, FormGroup, InputGroup, FormControl, ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import Icon from 'react-fontawesome';
 import { VALID_TASK } from '../../utils';
@@ -111,12 +111,12 @@ export default class SearchForm extends React.PureComponent {
         </Col>
 
         <Col lg={2} md={2} sm={4} style={{ padding: 0 }}>
-          <ButtonGroup style={{ marginBottom: 15 }}>
-            <Button
-              type="submit"
-              disabled={!valid.form}>
+          <ButtonGroup justified style={{ marginBottom: 15 }}>
+            <a
+              onClick={valid.form ? this.handleSubmit : null}
+              className={`btn btn-default${valid.form ? '' : ' btn-disabled'}`}>
               <Icon name="search" /> Inspect
-            </Button>
+            </a>
             <DropdownButton
               title="History"
               id="history-dropdown"

--- a/src/views/UnifiedInspector/SearchForm.js
+++ b/src/views/UnifiedInspector/SearchForm.js
@@ -84,74 +84,72 @@ export default class SearchForm extends React.PureComponent {
 
     return (
       <Form onSubmit={this.handleSubmit} horizontal>
-        <Col lg={10} md={10} sm={9}>
-          <FormGroup validationState={valid.taskGroupId ? null : 'error'}>
+        <Col lg={5} md={5} sm={4}>
+          <FormGroup validationState={valid.taskGroupId ? null : 'error'} style={{ marginRight: 0 }}>
             <InputGroup>
-              <InputGroup.Addon style={{ textAlign: 'left' }}>Task Group</InputGroup.Addon>
+              <InputGroup.Addon style={{ textAlign: 'left' }}>TaskGroupId</InputGroup.Addon>
               <FormControl
                 type="text"
-                placeholder="Enter a task group ID, e.g. 8U3xVyssSBuinaXwRgJ_qQ"
+                placeholder="Enter a task group ID"
                 value={taskGroupIdInput}
-                onChange={this.handleTaskGroupIdInputChange} />
-            </InputGroup>
-          </FormGroup>
-
-          <FormGroup validationState={valid.taskId ? null : 'error'}>
-            <InputGroup>
-              <InputGroup.Addon style={{ textAlign: 'left' }}>Task</InputGroup.Addon>
-              <FormControl
-                type="text"
-                placeholder="Enter a task ID or choose one from Tasks, e.g. 8U3xVyssSBuinaXwRgJ_qQ"
-                value={taskIdInput}
-                onChange={this.handleTaskIdInputChange} />
+                onChange={this.handleTaskGroupIdInputChange}
+                style={{ fontFamily: 'monospace' }} />
             </InputGroup>
           </FormGroup>
         </Col>
 
-        <Col lg={2} md={2} sm={3}>
-          <Col sm={12} style={{ marginBottom: 15, padding: 0 }}>
+        <Col lg={5} md={5} sm={4}>
+          <FormGroup validationState={valid.taskId ? null : 'error'} style={{ marginRight: 0 }}>
+            <InputGroup>
+              <InputGroup.Addon style={{ textAlign: 'left' }}>TaskId</InputGroup.Addon>
+              <FormControl
+                type="text"
+                placeholder="Enter a task ID or choose one from Tasks"
+                value={taskIdInput}
+                onChange={this.handleTaskIdInputChange}
+                style={{ fontFamily: 'monospace' }} />
+            </InputGroup>
+          </FormGroup>
+        </Col>
+
+        <Col lg={2} md={2} sm={4} style={{ padding: 0 }}>
+          <ButtonGroup>
             <Button
               type="submit"
-              disabled={!valid.form}
-              block>
+              disabled={!valid.form}>
               <Icon name="search" /> Inspect
             </Button>
-          </Col>
-          <Col sm={12} style={{ marginBottom: 15, padding: 0 }}>
-            <ButtonGroup justified>
-              <DropdownButton
-                title="History"
-                id="history-dropdown"
-                style={{ width: '100%' }}
-                disabled={!taskGroupHistory.length && !taskHistory.length}
-                pullRight>
-                <MenuItem header>Task Groups</MenuItem>
-                {taskGroupHistory.length ?
-                  (
-                    taskGroupHistory.map((taskGroupId, index) => (
-                      <LinkContainer to={`/groups/${taskGroupId}`} key={`group-history-${index}`}>
-                        <MenuItem>{taskGroupId}</MenuItem>
-                      </LinkContainer>
-                    ))
-                  ) :
-                  null
-                }
+            <DropdownButton
+              title="History"
+              id="history-dropdown"
+              disabled={!taskGroupHistory.length && !taskHistory.length}
+              pullRight>
+              <MenuItem header>Task Groups</MenuItem>
+              {taskGroupHistory.length ?
+                (
+                  taskGroupHistory.map((taskGroupId, index) => (
+                    <LinkContainer to={`/groups/${taskGroupId}`} key={`group-history-${index}`}>
+                      <MenuItem>{taskGroupId}</MenuItem>
+                    </LinkContainer>
+                  ))
+                ) :
+                null
+              }
 
-                <MenuItem divider />
-                <MenuItem header>Tasks</MenuItem>
-                {taskHistory.length ?
-                  (
-                    taskHistory.map((taskId, index) => (
-                      <LinkContainer to={`/tasks/${taskId}`} key={`task-history-${index}`}>
-                        <MenuItem>{taskId}</MenuItem>
-                      </LinkContainer>
-                    ))
-                  ) :
-                  null
-                }
-              </DropdownButton>
-            </ButtonGroup>
-          </Col>
+              <MenuItem divider />
+              <MenuItem header>Tasks</MenuItem>
+              {taskHistory.length ?
+                (
+                  taskHistory.map((taskId, index) => (
+                    <LinkContainer to={`/tasks/${taskId}`} key={`task-history-${index}`}>
+                      <MenuItem>{taskId}</MenuItem>
+                    </LinkContainer>
+                  ))
+                ) :
+                null
+              }
+            </DropdownButton>
+          </ButtonGroup>
         </Col>
       </Form>
     );


### PR DESCRIPTION
https://screenshots.firefox.com/1qopUqm2viS0SVSy/localhost

No idea if it's elegant on mobile... 

We should probably move the "notify me on changes" check box next to the progress bar... to make it even better...

Also I'm consistently confused by runs/artifacts/actions, I'm not sure how the navigation should work but a top-level tab bar isn't good... Maybe something like: https://screenshots.firefox.com/HDH8Rnott22qDIes/wireframe.cc  (https://wireframe.cc/P7EQQ7)
Where the list of task in a task-graph is a side-bar that slides in/out and overlays the task-inspector...