### PR TITLE
Add documentation comment

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,6 +69,7 @@ export const getLoginUrl = (location = window.location) => {
   return `https://login.taskcluster.net/?${query.toString()}`;
 };
 
+// Transform task to a loaner task
 export const parameterizeTask = task => merge(omit([
   'taskGroupId',
   // 'schedulerId',


### PR DESCRIPTION
We really should rename the method...

I just quickly spottet this, and figured I should file something. We really should rename it, this has to do with loaners, not some "generic parameterization of tasks".