### PR TITLE
Bug 1380091 - Fix the "More namespaces" button on index artifact browser

### DIFF
--- a/src/components/IndexBrowser/index.js
+++ b/src/components/IndexBrowser/index.js
@@ -33,20 +33,27 @@ export default class IndexBrowser extends React.PureComponent {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.namespaceToken !== this.state.namespaceToken ||
+      prevState.tasksToken !== this.state.tasksToken) {
+      this.loadTasksAndNamespaces(this.props);
+    }
+  }
+
   async loadTasksAndNamespaces({ index, namespace }) {
     try {
       this.setState({
         error: null,
         namespaceInput: namespace,
-        namespaces: await index.listNamespaces(namespace, { continuationToken: this.state.namespaceToken }),
-        tasks: await index.listTasks(namespace, { continuationToken: this.state.tasksToken })
+        tasks: await index.listTasks(namespace, { continuationToken: this.state.tasksToken || undefined }),
+        namespaces: await index.listNamespaces(namespace, { continuationToken: this.state.namespaceToken || undefined })
       });
     } catch (err) {
       this.setState({
         error: err,
         namespaceInput: namespace,
-        namespaces: null,
-        tasks: null
+        tasks: null,
+        namespaces: null
       });
     }
   }


### PR DESCRIPTION
Presently, when "More namespaces" button is clicked, the state is changed but `loadTasksAndNamespaces` is not being called as a callback. Previously, we [used to have](https://github.com/taskcluster/taskcluster-tools/blob/3e713b1f15b62287630aa7d83f05ab12cf198ae2/src/index/indexbrowser.jsx#L19)
a mixin with `reloadOnKeys` in the IndexBrowser component which would refresh the rendered list when either `namespaceToken` or `tasksToken` changes.

Since we are not using mixins anymore, I added this logic in [componentDidUpdate](https://facebook.github.io/react/docs/react-component.html#componentdidupdate).

Button works now!