### PR TITLE
Bug 1380098 - Make ArtifactList aware of credentials

### DIFF
--- a/src/components/ArtifactList/index.js
+++ b/src/components/ArtifactList/index.js
@@ -14,6 +14,7 @@ export default class ArtifactList extends React.PureComponent {
     ]),
     menu: bool,
     queue: object.isRequired,
+    credentials: object,
     style: object
   };
 

--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -372,7 +372,6 @@ export default class Inspector extends React.PureComponent {
   renderTaskGroup() {
     const { taskGroupId, taskId, queue, purgeCache, url, runId, sectionId, subSectionId, artifactId } = this.props;
     const { tasks, status, task, selectedTaskId, selectedRun, artifacts } = this.state;
-
     const trackedTaskId = taskId || selectedTaskId;
     const runNumber = this.getRunNumber(runId, selectedRun, status ? status.runs : []);
     const logs = artifacts && this.getLogsFromArtifacts(artifacts);
@@ -432,6 +431,7 @@ export default class Inspector extends React.PureComponent {
               queue={queue}
               taskId={trackedTaskId}
               artifacts={artifacts}
+              credentials={this.props.credentials}
               runId={runNumber} />
             <PropsRoute
               path={PATHS.LOG}

--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -372,6 +372,7 @@ export default class Inspector extends React.PureComponent {
   renderTaskGroup() {
     const { taskGroupId, taskId, queue, purgeCache, url, runId, sectionId, subSectionId, artifactId } = this.props;
     const { tasks, status, task, selectedTaskId, selectedRun, artifacts } = this.state;
+
     const trackedTaskId = taskId || selectedTaskId;
     const runNumber = this.getRunNumber(runId, selectedRun, status ? status.runs : []);
     const logs = artifacts && this.getLogsFromArtifacts(artifacts);

--- a/src/views/UnifiedInspector/index.js
+++ b/src/views/UnifiedInspector/index.js
@@ -17,6 +17,7 @@ const View = ({ credentials, match, history, location }) => {
           {...clients}
           url={match.url}
           history={history}
+          credentials={credentials}
           highlight={hasHighlight ? highlight : null}
           taskGroupId={match.params.taskGroupId}
           taskId={match.params.taskId}


### PR DESCRIPTION
Create an interactive task from any task and head over to "Run Artifacts" tab view. ArtifactList component was not aware of the user credentials so the shell.sh artifact displayed an "I" cursor and wouldn't allow you to click on it. This PR solves this issue.