### PR TITLE
[interactive] Provide easy to go link for resolved task.

### DIFF
--- a/src/views/InteractiveConnect/InteractiveConnect.js
+++ b/src/views/InteractiveConnect/InteractiveConnect.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Alert, Button, Label } from 'react-bootstrap';
+import Tooltip from 'react-tooltip';
 import { Link } from 'react-router-dom';
 import Icon from 'react-fontawesome';
 import { WebListener } from 'taskcluster-client';
@@ -245,8 +246,12 @@ export default class InteractiveConnect extends React.PureComponent {
     if (['completed', 'failed', 'exception'].includes(status.state)) {
       return (
         <Alert bsStyle="warning">
-          <strong>Task Resolved!</strong> You can not attach to an interactive task after it has
+          <strong><Link to={`/tasks/${taskId}`} data-tip={true} data-for={taskId}>Task</Link> Resolved!</strong>
+          You can not attach to an interactive task after it has
           stopped running.
+          <Tooltip id={taskId} type="info" effect="float" place="top">
+            {taskId}
+          </Tooltip>
         </Alert>
       );
     }


### PR DESCRIPTION
When the task is resolved, the UI provides no link to the task. We have
the task ID in the URL, but besides it is unintuitive (a user hardly
will figure out it), you have to copy the ID, open the task-inspector
and paste it to get task info.

We format the "resolved" message to include the link to the task to get
detailed info about it.