### PR TITLE
Bug 1359468 - Persist created/deadline fields when clicking on "Edit Task"

### DIFF
--- a/src/views/UnifiedInspector/ActionsMenu.js
+++ b/src/views/UnifiedInspector/ActionsMenu.js
@@ -99,16 +99,9 @@ export default class ActionsMenu extends React.PureComponent {
     'taskGroupId',
     'schedulerId',
     'priority',
-    'created',
-    'deadline',
     'dependencies',
     'requires'
-  ], {
-    ...this.props.task,
-    // filled in by task creator on load
-    created: null,
-    deadline: null
-  });
+  ], this.props.task);
 
   scheduleTask = () => this.props.queue.scheduleTask(this.props.taskId);
 


### PR DESCRIPTION
See [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1359468#c7) for bug explanation. This seems to have been a regression introduced with the Tools rewrite.