### PR TITLE
Navigate to new task after retriggering

### DIFF
--- a/src/views/UnifiedInspector/ActionsMenu.js
+++ b/src/views/UnifiedInspector/ActionsMenu.js
@@ -90,6 +90,8 @@ export default class ActionsMenu extends React.PureComponent {
       created: new Date(now).toJSON(),
       dependencies: task.dependencies.filter(requiredTask => requiredTask !== taskId)
     }));
+
+    return taskId;
   };
 
   // copy fields from the parent task, intentionally excluding some


### PR DESCRIPTION
Retriggering a task currently does not navigate the user to the new taskId. This PR fixes the issue.