### PR TITLE
Update URL to Github app

### DIFF
--- a/src/views/QuickStart/index.js
+++ b/src/views/QuickStart/index.js
@@ -279,7 +279,7 @@ export default class YamlCreator extends React.Component {
               </li>
               <li>
                 Make sure to install
-                the <a href="https://github.com/integration/taskcluster" target="_blank" rel="noopener noreferrer">
+                the <a href="https://github.com/apps/taskcluster" target="_blank" rel="noopener noreferrer">
                 Taskcluster-GitHub integration</a>.
               </li>
             </ul>


### PR DESCRIPTION
Github renamed "integration" to "app" and apparently couldn't be
bothered to 302 old URLs.