### PR TITLE
Be able to edit tasks that have properties set as null

### DIFF
--- a/src/views/TaskCreator/TaskCreator.js
+++ b/src/views/TaskCreator/TaskCreator.js
@@ -79,6 +79,10 @@ export default class TaskCreator extends React.PureComponent {
 
     // Increment all timestamps in the task by offset
     const iter = (obj) => {
+      if (!obj) {
+        return obj;
+      }
+
       switch (typeof obj) {
         case 'object':
           return Array.isArray(obj) ?


### PR DESCRIPTION
Editing [https://tools.taskcluster.net/groups/nr3qjGHwQ8eQTAze8L1PrQ/tasks/jpkXsb-US263L9o6jg66qw/details](https://tools.taskcluster.net/groups/nr3qjGHwQ8eQTAze8L1PrQ/tasks/jpkXsb-US263L9o6jg66qw/details) was producing `can't convert null to object`. `Object.entries()` received a null value and so it threw an error. I added a condition on top to fix that.

