### PR TITLE
Bug 1385373: [sign-in] Handle null certificates properly. r=Eli

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -87,13 +87,14 @@ export default class App extends React.Component {
   };
 
   loadCredentials() {
-    const credentials = JSON.parse(localStorage.getItem('credentials'));
+    const storedCredentials = localStorage.getItem('credentials');
 
     // We have no credentials
-    if (!credentials) {
+    if (!storedCredentials) {
       return { credentials: null };
     }
 
+    const credentials = JSON.parse(storedCredentials);
     const { certificate } = credentials;
     const isExpired = certificate && certificate.expiry < Date.now();
 
@@ -147,7 +148,7 @@ export default class App extends React.Component {
     this.saveCredentials({
       clientId,
       accessToken,
-      certificate: certificate === '' ? certificate : JSON.parse(certificate)
+      certificate: certificate ? JSON.parse(certificate) : null
     });
   };
 


### PR DESCRIPTION
Manual sign-in is busted because there are some places in the code where
null certificates are passed to JSON.parse, throwing an exception.

We check if the certifcates are falsy values and handle them
accordingly.