### PR TITLE
Expire secrets in 1000 years ("never") by default

### DIFF
--- a/src/views/SecretsManager/SecretEditor.js
+++ b/src/views/SecretsManager/SecretEditor.js
@@ -49,7 +49,7 @@ export default class SecretEditor extends React.PureComponent {
       return this.setState({
         secret: {},
         secretValue: '{}',
-        expires: fromNow('1 day'),
+        expires: fromNow('1000 years'),
         editing: true,
         working: false,
         error: null


### PR DESCRIPTION
The one-day expiration has bitten me several times, because you set up a
secret, everything works great, then you go to use it the next day and
wonder if you're losing your mind.