### PR TITLE
Prettify logviewer on mobile

### DIFF
--- a/src/views/UnifiedInspector/GroupProgress.js
+++ b/src/views/UnifiedInspector/GroupProgress.js
@@ -107,9 +107,12 @@ export default class GroupProgress extends React.PureComponent {
           ))}
         </ProgressBar>
 
-        <div>
+        <div style={{ display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap' }}>
           {groups.map((group, index) => (
-            <Label bsStyle={labels[group]} key={`legend-item-${index}`} style={{ borderRadius: 0, marginLeft: 10 }}>
+            <Label
+              bsStyle={labels[group]}
+              key={`legend-item-${index}`}
+              style={{ borderRadius: 0, marginLeft: 10, marginBottom: 5 }}>
               {group}
             </Label>
           ))}

--- a/src/views/UnifiedInspector/LogView.js
+++ b/src/views/UnifiedInspector/LogView.js
@@ -7,6 +7,8 @@ import { LazyLog, LazyStream, ScrollFollow } from 'react-lazylog';
 import { isNil } from 'ramda';
 import fscreen from 'fscreen';
 
+const VIEWER_HEIGHT_MIN = 400;
+
 const buttonStyle = {
   margin: '10px 0 10px 10px'
 };
@@ -90,7 +92,9 @@ export default class LogView extends React.PureComponent {
 
   handleLazyViewerHeight = () => {
     if (this.lazylog) {
-      this.setState({ lazyViewerHeight: window.innerHeight - this.lazylog.getBoundingClientRect().top });
+      const lazyViewerHeight = window.innerHeight - this.lazylog.getBoundingClientRect().top;
+
+      this.setState({ lazyViewerHeight: lazyViewerHeight > VIEWER_HEIGHT_MIN ? lazyViewerHeight : VIEWER_HEIGHT_MIN });
     }
   };
 


### PR DESCRIPTION
This pull-request incorporates 2 changes:
1. Provide the logviewer a minimal height of 400px
- Currently the logviewer height is dynamically calculated so that it sits nicely on the bottom of the screen. On mobile however, the height is really tiny and so you only see one or two lines of the log. To fix this issue, I provided the component a minimal height of 400px, big enough for mobile users to interact with the viewer.

2. Use flexbox to wrap the status label in mobile
- On mobile, the status labels are overflowing the screen horizontally and this makes the eyes bleed. Flexbox is used to fix this issue. Below are the before and after visuals.

## Before
![screen shot 2017-08-23 at 11 27 19 am](https://user-images.githubusercontent.com/3766511/29624067-33063bb0-87f6-11e7-9ae1-76089bba448e.png)

![screen shot 2017-08-23 at 11 25 57 am](https://user-images.githubusercontent.com/3766511/29623988-0133b298-87f6-11e7-9af5-64f0ee8ca59e.png)

## After
![screen shot 2017-08-23 at 11 28 10 am](https://user-images.githubusercontent.com/3766511/29624121-51178c8a-87f6-11e7-92c0-8d1a0036b050.png)

