### PR TITLE
Load artifacts and logs when switching runs

### DIFF
--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -111,8 +111,9 @@ export default class Inspector extends React.PureComponent {
       (taskId !== this.state.selectedTaskId || (this.props.taskId && taskId !== this.props.taskId))
     ) {
       this.loadTask(nextProps);
-    } else if (runId && runId !== this.props.runId) {
+    } else if (Number.isInteger(runId) && runId !== this.props.runId) {
       this.setState({ selectedRun: runId });
+      this.loadTask(nextProps);
     } else if (this.state.error && !equal(nextProps.credentials, this.props.credentials)) {
       this.setState({ error: null });
     }

--- a/src/views/UnifiedInspector/Inspector.js
+++ b/src/views/UnifiedInspector/Inspector.js
@@ -79,7 +79,7 @@ export default class Inspector extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  async componentWillReceiveProps(nextProps) {
     const { taskGroupId, taskId, runId } = nextProps;
 
     if (taskGroupId !== this.props.taskGroupId) {
@@ -112,8 +112,12 @@ export default class Inspector extends React.PureComponent {
     ) {
       this.loadTask(nextProps);
     } else if (Number.isInteger(runId) && runId !== this.props.runId) {
-      this.setState({ selectedRun: runId });
-      this.loadTask(nextProps);
+      this.setState({
+        selectedRun: runId,
+        artifacts: this.state.status.state !== 'unscheduled' ?
+          await this.getArtifacts(this.props.taskId, runId) :
+          []
+      });
     } else if (this.state.error && !equal(nextProps.credentials, this.props.credentials)) {
       this.setState({ error: null });
     }


### PR DESCRIPTION
STR: Head over to the Task & Group Inspector. Set the `taskId` to `Ev_1g8xrTXS1thHi7649Ww` and click Inspect. You will notice that Task run 1 has no logs and no artifacts. Switching to run 0 is not updating that list, therefore still showing no logs and no artifacts.
