### PR TITLE
Round value from getBoundingClientRect

### DIFF
--- a/src/views/UnifiedInspector/LogView.js
+++ b/src/views/UnifiedInspector/LogView.js
@@ -92,7 +92,7 @@ export default class LogView extends React.PureComponent {
 
   handleLazyViewerHeight = () => {
     if (this.lazylog) {
-      const lazyViewerHeight = window.innerHeight - this.lazylog.getBoundingClientRect().top;
+      const lazyViewerHeight = window.innerHeight - Math.round(this.lazylog.getBoundingClientRect().top);
 
       if (lazyViewerHeight > VIEWER_HEIGHT_MIN) {
         this.setState({ lazyViewerHeight });


### PR DESCRIPTION
This should fix the follow log issue people were having in #275.

From the same line I made the change, the if condition never resolved because there was a very small offset (0 < offset < 1) in the calculation.

It turns out it came from `this.lazylog.getBoundingClientRect().top` where the value returned was a float. Rounding it off to match the other methods we use to calculate heights fixed the issue.