### PR TITLE
Log resizing

### DIFF
--- a/src/views/UnifiedInspector/LogView.js
+++ b/src/views/UnifiedInspector/LogView.js
@@ -43,6 +43,10 @@ export default class LogView extends React.PureComponent {
     window.addEventListener('resize', this.handleLazyViewerHeight);
   }
 
+  componentDidMount() {
+    this.handleLazyViewerHeight();
+  }
+
   componentWillUnmount() {
     fscreen.removeEventListener('fullscreenchange', this.handleFullscreenChange);
     window.removeEventListener('resize', this.handleLazyViewerHeight);


### PR DESCRIPTION
STR:

- Load a task e.g., [DM4ksqEhTEeW9INJPxMAiQ](https://tools.taskcluster.net/groups/HFz65TTvQfSPJFtbVYNqkg/tasks/DM4ksqEhTEeW9INJPxMAiQ/runs/0/logs/public%2Flogs%2Flive_backing.log)
- Wait around 20 seconds for `componentDidUpdate` to stop being triggered
- Click on a different tab e.g., "Run Artifacts"
- Head back to the logviewer e.g., "Run Logs" -> "public/logs/live.log"

Expected: The logviewer covers the screen all the way to the bottom
Actual: The logviewer is 400px high (see image below)

Presently, we handle the logviewer height in `componentDidUpdate`.  This method however is not called for the initial render. That's why the logviewer height is taking the default 400px height when switching tabs and coming back to it. To solve this issue, `componentDidMount` is used to call `handleLazyViewerHeight`.

![screenshot from 2017-09-18 09-11-07](https://user-images.githubusercontent.com/3766511/30549739-9373736a-9c63-11e7-87ed-3fb77bec3182.png)

