### PR TITLE
Delete pending label

### DIFF
--- a/src/views/WorkerManager/WorkerTable.js
+++ b/src/views/WorkerManager/WorkerTable.js
@@ -21,8 +21,6 @@ export default class WorkerTable extends React.PureComponent {
     this.state = {
       filterStatus: 'all'
     };
-
-    delete labels.pending;
   }
 
   renderTaskDescription = description => (
@@ -97,7 +95,9 @@ export default class WorkerTable extends React.PureComponent {
   };
 
   render() {
-    const groups = Object.keys(labels);
+    const groups = Object
+      .keys(labels)
+      .filter(label => !label.includes('pending'));
     const tasksToRender = this.tasksToRender();
     const { filterStatus } = this.state;
 

--- a/src/views/WorkerManager/WorkerTable.js
+++ b/src/views/WorkerManager/WorkerTable.js
@@ -21,6 +21,8 @@ export default class WorkerTable extends React.PureComponent {
     this.state = {
       filterStatus: 'all'
     };
+
+    delete labels.pending;
   }
 
   renderTaskDescription = description => (


### PR DESCRIPTION
A task will never be in this list for a particular worker in a state of pending. Tasks are only associated with workers once a run has been claimed.