### PR TITLE
firstClaim not recorded to return '-'

### DIFF
--- a/src/views/WorkerManager/WorkerManager.js
+++ b/src/views/WorkerManager/WorkerManager.js
@@ -138,6 +138,7 @@ export default class WorkerManager extends React.PureComponent {
           'Disabling a worker allows the machine to remain alive but not accept jobs.'}
       </Tooltip>
     );
+    const firstClaim = worker && moment(worker.firstClaim);
 
     return (
       <div>
@@ -177,7 +178,7 @@ export default class WorkerManager extends React.PureComponent {
               <tbody>
                 <tr>
                   <td>First Claim</td>
-                  <td>{moment(worker.firstClaim).fromNow()}</td>
+                  <td>{firstClaim.isAfter('2000-01-01') ? firstClaim.fromNow() : '-'}</td>
                 </tr>
                 <tr>
                   <td style={{ verticalAlign: 'inherit' }}>Actions</td>


### PR DESCRIPTION
Old workers that didn't have `firstClaim` were all migrated to year 2000 [taskcluster/taskcluster-queue/blob/master/src/data.js#L889](https://github.com/taskcluster/taskcluster-queue/blob/master/src/data.js#L889).

You don't want the UI to show 18 years ago. This PR returns `-` in that case to remove confusion.