### PR TITLE
Reduce re-renders in inspector, improve travis build times by removing sourcemap

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,4 +1,3 @@
-const env = require('neutrino-middleware-env');
 const merge = require('deepmerge');
 const { ProvidePlugin } = require('webpack');
 
@@ -56,6 +55,7 @@ module.exports = {
       // Fix issue with nested routes e.g /index/garbage
       neutrino.config.output.publicPath('/');
       neutrino.config.node.set('Buffer', true);
+      neutrino.config.when(process.env.CI === 'true', (config) => config.devtool(false));
 
       neutrino.config.module
         .rule('plain-style')


### PR DESCRIPTION
I'm trying to improve the performance of the inspector by:

* Loading minimal records up-front, then downloading in batches of 200
* Reduce requests made in series in favor of parallel
* Improve rendering by storing up a couple `setState`s into a single call
* Don't `await` tasks continuation, just continue during animation frame

Also this should hopefully improve the time of travis builds by shutting off source maps in CI.