### PR TITLE
Bug 1404340 - [dashboard] no workers shown sometimes

### DIFF
--- a/src/views/Workers/WorkerManager.js
+++ b/src/views/Workers/WorkerManager.js
@@ -45,6 +45,15 @@ export default class WorkerManager extends React.PureComponent {
         () => this.loadWorkers(this.props)
       );
     }
+
+    // Edge case with azure not returning a list but has a continuationToken
+    if (
+      this.state.workers &&
+      !this.state.workers.workers.length &&
+      this.state.workers.continuationToken
+    ) {
+      this.nextWorkers();
+    }
   }
 
   loadStatus = async taskId => {


### PR DESCRIPTION
Sometimes the list of workers is empty but then clicking on "more workers" returns a list of workers. Azure doesn't guarantee a result list but as long as you have a continuationToken, you should continue looping.

To that end, If a search doesn't give a result, we should fetch again with the continuation token until a list is returned or the token becomes undefined. That way, a user won't find himself looking at an empty page with the "More workers" button enabled