### PR TITLE
Add breadcrumb component

### DIFF
--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Breadcrumb as Nav } from 'react-bootstrap';
+import { arrayOf, string, object, oneOfType } from 'prop-types';
+
+export default class Breadcrumb extends React.PureComponent {
+  isActive = title =>
+    typeof this.props.active === 'string'
+      ? this.props.active === title
+      : this.props.active.includes(title);
+
+  render() {
+    return (
+      <Nav>
+        {this.props.navList.map((entry, key) => (
+          <Nav.Item
+            key={`breadcrumb-${key}`}
+            active={this.isActive(entry.title)}
+            href={entry.href}>
+            {entry.title}
+          </Nav.Item>
+        ))}
+      </Nav>
+    );
+  }
+}
+
+Breadcrumb.propTypes = {
+  active: oneOfType([string, arrayOf(string)]).isRequired,
+  navList: arrayOf(object).isRequired
+};

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -3,10 +3,15 @@ import { Breadcrumb as Nav } from 'react-bootstrap';
 import { arrayOf, string, object, oneOfType } from 'prop-types';
 
 export default class Breadcrumb extends React.PureComponent {
-  isActive = title =>
-    typeof this.props.active === 'string'
+  isActive = title => {
+    if (!this.props.active) {
+      return this.props.navList.slice(-1) === title;
+    }
+
+    return typeof this.props.active === 'string'
       ? this.props.active === title
       : this.props.active.includes(title);
+  };
 
   render() {
     return (
@@ -25,6 +30,6 @@ export default class Breadcrumb extends React.PureComponent {
 }
 
 Breadcrumb.propTypes = {
-  active: oneOfType([string, arrayOf(string)]).isRequired,
+  active: oneOfType([string, arrayOf(string)]),
   navList: arrayOf(object).isRequired
 };


### PR DESCRIPTION
We're using `Breadcrumb` in many of our views now so I think putting it under the components folder would be nice :) With this PR, you only need to do:

```jsx
// inside link2 view
const navList = [
  {
    title: 'titleA',
    href: '/link1'
  },
  {
    title: 'titleB',
    href: '/link2
  }
];

<Breadcrumb navList={navList} active="titleB" /> 