### PR TITLE
Bug 1344409 - Drop the timestamp warning in Task Creator after "Update Timestamps" is clicked

### DIFF
--- a/src/views/TaskCreator/TaskCreator.js
+++ b/src/views/TaskCreator/TaskCreator.js
@@ -146,7 +146,10 @@ export default class TaskCreator extends React.PureComponent {
   };
 
   handleUpdateTimestamps = () =>
-    this.setState({ task: this.parameterizeTask(safeLoad(this.state.task)) });
+    this.setState({
+      createdTaskError: null,
+      task: this.parameterizeTask(safeLoad(this.state.task))
+    });
 
   handleResetEditor = () =>
     this.setState({ task: this.parameterizeTask(defaultTask) });

--- a/src/views/TaskCreator/TaskCreator.js
+++ b/src/views/TaskCreator/TaskCreator.js
@@ -152,7 +152,10 @@ export default class TaskCreator extends React.PureComponent {
     });
 
   handleResetEditor = () =>
-    this.setState({ task: this.parameterizeTask(defaultTask) });
+    this.setState({
+      createdTaskError: null,
+      task: this.parameterizeTask(defaultTask)
+    });
 
   renderState() {
     const { task, error } = this.state;


### PR DESCRIPTION
All the error warnings are dropped when "Update Timestamps" is clicked. User needs to click "Create Task" again to check.