### PR TITLE
Added ScopeGrants tool for easy granting of scopes

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -51,6 +51,9 @@ const RoleManager = loadable(() =>
 const ScopeInspector = loadable(() =>
   import(/* webpackChunkName: 'ScopeInspector' */ '../views/ScopeInspector')
 );
+const ScopeGrants = loadable(() =>
+  import(/* webpackChunkName: 'ScopeGrants' */ '../views/ScopeGrants')
+);
 const PulseInspector = loadable(() =>
   import(/* webpackChunkName: 'PulseInspector' */ '../views/PulseInspector')
 );
@@ -250,6 +253,11 @@ export default class App extends React.Component {
                 <PropsRoute
                   path="/auth/scopes/:selectedScope?/:selectedEntity?"
                   component={ScopeInspector}
+                  userSession={userSession}
+                />
+                <PropsRoute
+                  path="/auth/grants/:pattern?"
+                  component={ScopeGrants}
                   userSession={userSession}
                 />
                 <PropsRoute

--- a/src/links.js
+++ b/src/links.js
@@ -58,6 +58,12 @@ export default [
       clients with a given scope. This is effectively reverse client and role lookup.`
   },
   {
+    title: 'Scope Grants',
+    link: '/auth/grants/',
+    icon: 'check',
+    description: `Grant scopes....`
+  },
+  {
     title: 'Pulse Inspector',
     link: '/pulse-inspector',
     icon: 'wifi',

--- a/src/links.js
+++ b/src/links.js
@@ -61,7 +61,8 @@ export default [
     title: 'Scope Grants',
     link: '/auth/grants/',
     icon: 'check',
-    description: `Grant scopes....`
+    description: `Grant scopes following predefined patterns for how scopes can be granted to
+      roles associated with entities like a repository, hook, user, etc.`
   },
   {
     title: 'Pulse Inspector',

--- a/src/views/ScopeGrants/ScopeGrants.js
+++ b/src/views/ScopeGrants/ScopeGrants.js
@@ -1,0 +1,377 @@
+import React from 'react';
+import {
+  Row,
+  Col,
+  Button,
+  Glyphicon,
+  ListGroup,
+  ListGroupItem,
+  Table,
+  Form,
+  FormGroup,
+  ControlLabel,
+  FormControl
+} from 'react-bootstrap';
+import R from 'ramda';
+import Icon from 'react-fontawesome';
+import Error from '../../components/Error';
+import Spinner from '../../components/Spinner';
+import UserSession from '../../auth/UserSession';
+import HelmetTitle from '../../components/HelmetTitle';
+import Markdown from '../../components/Markdown';
+import ModalItem from '../../components/ModalItem';
+import PATTERNS from './patterns';
+import { instantiate, instantiatedArguments } from './granting';
+
+export default class ScopeGrants extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      roles: null,
+      error: null,
+      selected: null,
+      args: {}
+    };
+  }
+
+  componentWillMount() {
+    this.load();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      UserSession.userChanged(this.props.userSession, nextProps.userSession)
+    ) {
+      this.setState({ error: null });
+    }
+
+    if (this.props.pattern !== nextProps.pattern) {
+      this.setState({ selected: null, args: {} });
+    }
+  }
+
+  async load() {
+    try {
+      this.setState({
+        roles: await this.props.auth.listRoles(),
+        error: null
+      });
+    } catch (err) {
+      this.setState({
+        roles: null,
+        clients: null,
+        error: err
+      });
+    }
+  }
+
+  renderGrants() {
+    if (this.state.error) {
+      return <Error error={this.state.error} />;
+    }
+
+    if (!this.state.roles) {
+      return <Spinner />;
+    }
+
+    const pattern = PATTERNS.find(p => p.name === this.props.pattern);
+    const instantiatedArgs = instantiatedArguments(pattern, this.state.roles);
+    const params = Object.keys(pattern.params);
+
+    return (
+      <Row>
+        <Col md={12}>
+          <HelmetTitle title={pattern.title} />
+          <Row>
+            <Col md={1}>
+              <Button onClick={() => this.props.history.push(`/auth/grants/`)}>
+                <Glyphicon glyph="chevron-left" /> Back
+              </Button>
+            </Col>
+            <Col md={10}>
+              <h2>
+                <Icon name={pattern.icon} /> {pattern.title}
+              </h2>
+              <Markdown>{pattern.description}</Markdown>
+            </Col>
+          </Row>
+          <hr />
+          <Row>
+            <Col md={6}>
+              <Table hover>
+                <thead>
+                  <tr>
+                    {params.map((param, index) => <th key={index}>{param}</th>)}
+                  </tr>
+                </thead>
+                <tbody>
+                  {instantiatedArgs.map((args, index) => (
+                    <tr
+                      key={index}
+                      style={{ cursor: 'pointer' }}
+                      className={
+                        R.equals(args, this.state.selected) ? 'info' : null
+                      }
+                      onClick={() => this.setState({ selected: args })}>
+                      {params.map((param, index) => (
+                        <td key={index}>
+                          <code>{args[param]}</code>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+              <hr />
+              <Button
+                onClick={() => this.setState({ selected: null, args: {} })}>
+                <Glyphicon glyph="plus" /> New Grant
+              </Button>
+              <br />
+              <br />
+            </Col>
+            <Col md={6}>
+              {!this.state.selected
+                ? this.renderCreateForm(pattern)
+                : this.renderPatternInstance(pattern, this.state.selected)}
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    );
+  }
+
+  renderCreateForm(pattern) {
+    const params = Object.keys(pattern.params);
+    const { args } = this.state;
+    const save = async () => {
+      const instance = instantiate(pattern, this.state.args);
+      const roles = await this.props.auth.listRoles();
+      const toCreate = [];
+      const toUpdate = [];
+
+      Object.keys(instance).forEach(r => {
+        if (roles.some(({ roleId }) => r === roleId)) {
+          toUpdate.push(r);
+        } else {
+          toCreate.push(r);
+        }
+      });
+
+      await Promise.all([
+        ...toCreate.map(role =>
+          this.props.auth.createRole(role, {
+            description: '',
+            scopes: instance[role]
+          })
+        ),
+        ...toUpdate.map(role => {
+          const { scopes, description } = roles.find(
+            ({ roleId }) => roleId === role
+          );
+
+          return this.props.auth.updateRole(role, {
+            description,
+            scopes: R.uniq([...scopes, ...instance[role]])
+          });
+        })
+      ]);
+    };
+
+    const reload = async () => {
+      this.setState({ selected: null, roles: null, args: {} });
+      await this.load();
+      this.setState({ selected: args });
+    };
+
+    const setArg = (param, text) => {
+      this.setState({ args: R.merge(this.state.args, { [param]: text }) });
+    };
+
+    const validateArg = param =>
+      this.state.args[param] &&
+      pattern.params[param].exec(this.state.args[param]);
+
+    return (
+      <span>
+        <h3>Grant Scopes</h3>
+        <Form horizontal>
+          {params.map((param, index) => (
+            <FormGroup
+              key={index}
+              validationState={validateArg(param) ? 'success' : 'error'}>
+              <Col componentClass={ControlLabel} sm={2}>
+                {param}
+              </Col>
+              <Col sm={10}>
+                <FormControl
+                  type="text"
+                  placeholder={pattern.params[param].source.slice(1, -1)}
+                  onChange={e => setArg(param, e.target.value)}
+                />
+                <FormControl.Feedback />
+              </Col>
+            </FormGroup>
+          ))}
+          <FormGroup>
+            <Col smOffset={2} sm={10}>
+              <ModalItem
+                button={true}
+                bsStyle="primary"
+                onSubmit={save}
+                disabled={!params.every(validateArg)}
+                onComplete={reload}
+                body={
+                  <span>
+                    Are you sure you want to <b>grant scopes</b>?
+                    <br />
+                    <br />
+                    {this.renderInstanceGrants(pattern, args)}
+                    This will create or update roles as necessary to create the
+                    above scope grants.
+                  </span>
+                }>
+                <Glyphicon glyph="plus" /> Grant Scopes
+              </ModalItem>
+            </Col>
+          </FormGroup>
+        </Form>
+      </span>
+    );
+  }
+
+  renderPatternInstance(pattern, args) {
+    const params = Object.keys(pattern.params);
+    const reload = () => {
+      this.setState({ selected: null, roles: null });
+      this.load();
+    };
+
+    const remove = async () => {
+      const instance = instantiate(pattern, this.state.selected);
+      const roles = await this.props.auth.listRoles();
+
+      await Promise.all(
+        roles
+          .filter(({ roleId }) => instance[roleId])
+          .map(({ roleId, description, scopes }) =>
+            this.props.auth.updateRole(roleId, {
+              description,
+              scopes: R.without(instance[roleId], scopes)
+            })
+          )
+      );
+    };
+
+    return (
+      <span>
+        <h3>Selected Parameters</h3>
+        <dl className="dl-horizontal">
+          {R.unnest(
+            params.map((param, index) => [
+              <dt key={param}>{param}</dt>,
+              <dd key={index}>
+                <code>{args[params]}</code>
+              </dd>
+            ])
+          )}
+        </dl>
+        <h3>Scope Grants</h3>
+        {this.renderInstanceGrants(pattern, args)}
+        <hr />
+        <ModalItem
+          button={true}
+          bsStyle="danger"
+          onSubmit={remove}
+          onComplete={reload}
+          body={
+            <span>
+              Are you sure you want to <b>remove scope grants</b> from role?
+              <br />
+              <br />
+              {this.renderInstanceGrants(pattern, args)}
+            </span>
+          }>
+          <Icon name="trash" /> Delete Grant
+        </ModalItem>
+      </span>
+    );
+  }
+
+  renderInstanceGrants(pattern, args) {
+    let inst;
+
+    try {
+      inst = instantiate(pattern, args);
+    } catch (err) {
+      return <Error error={err} />;
+    }
+
+    return (
+      <ul>
+        {Object.keys(inst).map((roleId, index) => (
+          <li key={index} className="list-unstyled">
+            <Icon name="users" fixedWidth={true} /> <code>{roleId}</code>
+            <ul>
+              {inst[roleId].map((scope, index) => (
+                <li key={index}>
+                  <code>{scope}</code>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  renderPatternSelector() {
+    return (
+      <Col smOffset={1} sm={10}>
+        <h2>Scope Grant Patterns</h2>
+        <p>
+          This <i>scope grant</i> tool is an administrative utility for granting
+          scopes by creating/updating roles following predefined patterns. These
+          patterns are declared in the taskcluster-tools repository. Each
+          pattern takes a set of parameters that is used to instantiate scope
+          patterns which are then granted to instantiated role patterns. Below
+          is a list of patterns supported, after selecting a pattern, this tool
+          will display existing instantiations of the pattern by inspecting
+          existing roles and offer a UI for creating new instantiations.
+        </p>
+        <br />
+        <ListGroup>
+          {PATTERNS.map(({ name, title, icon, description }, index) => (
+            <ListGroupItem
+              key={index}
+              header={
+                <h3>
+                  <Icon name={icon} /> {title}
+                </h3>
+              }
+              onClick={() => this.props.history.push(`/auth/grants/${name}`)}>
+              <Markdown>{description}</Markdown>
+            </ListGroupItem>
+          ))}
+        </ListGroup>
+      </Col>
+    );
+  }
+
+  render() {
+    if (
+      !this.props.pattern ||
+      !PATTERNS.some(p => p.name === this.props.pattern)
+    ) {
+      return (
+        <Row>
+          <HelmetTitle title="Grant Scopes" />
+          {this.renderPatternSelector()}
+        </Row>
+      );
+    }
+
+    return this.renderGrants();
+  }
+}

--- a/src/views/ScopeGrants/granting.js
+++ b/src/views/ScopeGrants/granting.js
@@ -1,5 +1,10 @@
-import assert from 'assert';
 import R from 'ramda';
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
 
 // cartesian product of multiple lists
 // xproduct([[a, b], [1, 2], [C]]) == [[a, 1, C], [a, 2, C], [b, 1, C], [b, 2, C]]

--- a/src/views/ScopeGrants/granting.js
+++ b/src/views/ScopeGrants/granting.js
@@ -1,0 +1,171 @@
+import assert from 'assert';
+import R from 'ramda';
+
+// cartesian product of multiple lists
+// xproduct([[a, b], [1, 2], [C]]) == [[a, 1, C], [a, 2, C], [b, 1, C], [b, 2, C]]
+const xproduct = R.reduce(R.pipe(R.xprod, R.map(R.unnest)), [[]]);
+// escape string for save usage in regular expression
+const escapeRegex = s => s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+// Extract regular expression without ^ and $, and assert that it doesn't contain
+// any capturing groups, and that it is fully anchored with ^ and $.
+const extractRegExpAsString = re => {
+  assert(re instanceof RegExp, 'expected a regular expression');
+  const src = re.source;
+
+  assert(
+    src[0] === '^' && src[src.length - 1] === '$',
+    'regular expression must be anchored'
+  );
+  const plain = src.slice(1, -1);
+
+  assert(
+    new RegExp(`^(?:|${plain})$`).exec('').length === 1,
+    'regular expression must be non-capturing'
+  );
+
+  return plain;
+};
+
+// Given a set of arguments: [{param: value, ...}, {param: value, ...}], merge
+// them and return the result; return null, if there are conflicting assignments.
+const mergeArgumentSets = argumentSets => {
+  const merged = {};
+  let conflict = false;
+
+  argumentSets.forEach(args => {
+    Object.keys(args).forEach(param => {
+      conflict = conflict || (merged[param] && merged[param] !== args[param]);
+      merged[param] = args[param];
+    });
+  });
+
+  if (conflict || argumentSets.length === 0) {
+    return null;
+  }
+
+  return merged;
+};
+
+export const instantiate = ({ params, grants }, args) => {
+  // Validate input
+  Object.keys(params).forEach(param => {
+    assert(
+      params[param].exec(args[param]),
+      `parameter ${param} was given illegal value ${args[param]}`
+    );
+  });
+
+  // Pattern matching parameters
+  const paramPattern = new RegExp(
+    Object.keys(params)
+      .map(p => `<(${escapeRegex(p)})>`)
+      .join('|'),
+    'g'
+  );
+  const parameterize = s =>
+    s.replace(paramPattern, (orig, param) => args[param]);
+  const result = {};
+
+  Object.keys(grants).forEach(rolePattern => {
+    result[parameterize(rolePattern)] = grants[rolePattern].map(parameterize);
+  });
+
+  return result;
+};
+
+/**
+ * instantiatedArguments returns a list of arguments on the form
+ * {param: value, ...} matching {param: regexp} from params, such that patterns
+ * given in grants have been instantied as role/scope assignments in roles.
+ */
+export const instantiatedArguments = ({ params, grants }, roles = []) => {
+  const paramPatterns = {};
+
+  Object.keys(params).forEach(param => {
+    paramPatterns[param] = extractRegExpAsString(params[param]);
+  });
+
+  // Pattern matching parameters
+  const paramPattern = new RegExp(
+    Object.keys(params)
+      .map(p => `<(${escapeRegex(p)})>`)
+      .join('|'),
+    'g'
+  );
+  // makeMatcher takes a pattern containing <param> and returns a match function
+  // such that match(str) = {<param>: value, ...} for each parameter, or null
+  // if the string str doesn't match the pattern given.
+  const makeMatcher = pattern => {
+    assert(typeof pattern === 'string');
+    const parameters = [];
+    const r = pattern
+      .split(paramPattern)
+      .map((part, i) => {
+        // even entries are raw text, odd entries are group matches
+        if (i % 2 === 0) {
+          return escapeRegex(part);
+        }
+
+        // Odd entries are parameter names
+        parameters.push(part);
+
+        return `(${paramPatterns[part]})`;
+      })
+      .join('');
+    const re = new RegExp(`^${r}$`);
+
+    return s => {
+      const m = re.exec(s);
+
+      if (!m) {
+        return null;
+      }
+
+      const args = {};
+
+      parameters.forEach((param, i) => {
+        args[param] = m[i + 1];
+      });
+
+      return args;
+    };
+  };
+
+  // For each {rolePattern: [...scopePatterns]} in grants (key/value pair in grants)
+  // we find the possible set of arguments: {param: value, ...}, for which the
+  // scopes matching scopePatterns have been granted to a role matching rolePattern
+  const rolePatternArgSets = R.toPairs(
+    grants
+  ).map(([rolePattern, scopePatterns]) => {
+    // Construct a function that will match rolePattern, by replacing <param>
+    // with the regular expression for the param. The matcher will return the
+    // arguments used in the string matched on the form: {param: value, ...}
+    const roleMatch = makeMatcher(rolePattern);
+    const scopeMatchers = scopePatterns.map(makeMatcher);
+
+    return roles
+      .filter(({ roleId }) => roleMatch(roleId))
+      .map(({ roleId, scopes }) => {
+        // Find a list of satisfied args for each scope pattern
+        const scopePatternArgSets = scopeMatchers.map(m =>
+          R.uniq(scopes.map(m).filter(a => a))
+        );
+
+        // We must satisfy one args for each scope pattern, as we have a
+        // list of args per scope-pattern, this becomes cartesian product
+        return xproduct([
+          [roleMatch(roleId)], // args required by role pattern
+          ...scopePatternArgSets // Array with args for each scope pattern
+        ])
+          .map(mergeArgumentSets)
+          .filter(a => a);
+      });
+  });
+
+  // Find the arguments for which all {rolePattern: [...scopePatterns]} pairs
+  // in grants have been instantiated. We have a list of arguments for each
+  // rolePattern, so we just take cross-product, merge and filter out nulls.
+  return xproduct(rolePatternArgSets)
+    .map(mergeArgumentSets)
+    .filter(a => a);
+};

--- a/src/views/ScopeGrants/index.js
+++ b/src/views/ScopeGrants/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import Clients from '../../components/Clients';
+import ScopeGrants from './ScopeGrants';
+
+const View = ({ userSession, match, history }) => {
+  const pattern = decodeURIComponent(match.params.pattern || '');
+
+  return (
+    <Clients userSession={userSession} Auth>
+      {({ auth }) => (
+        <ScopeGrants
+          auth={auth}
+          history={history}
+          userSession={userSession}
+          pattern={pattern}
+        />
+      )}
+    </Clients>
+  );
+};
+
+export default View;

--- a/src/views/ScopeGrants/patterns.js
+++ b/src/views/ScopeGrants/patterns.js
@@ -1,0 +1,59 @@
+/**
+ * Role-Scope Patterns,
+ *
+ * This document specifies role-scope patterns that can be granted and listed
+ * using the ScopeGrants tool, along with a usable description.
+ *
+ * WARNING: Modifying these patterns can cause maintenance nightmares and
+ *          configuration inconsistencies.
+ *
+ * If a pattern is changed here, the following will cause pain:
+ *  A) the existing grants will NOT be automatically updated (obviously).
+ *  B) The ScopeGrants tool will NOT be able to list existing grants.
+ *
+ * (A) is annoying as it means that existing grants have to be manually
+ * granted again. This is further complicated by (B) as we can't see the
+ * existing grants anymore. Thus, we risk:
+ *  i)  scope configuration inconsistencies (if some grants aren't re-granted)
+ *  ii) old grants go hidden and are hard to find, causing security concerns.
+ *
+ * TODO: Allow patterns to specify revisions of the {params, grants} properties.
+ *       Example: {revisions: [{params, grants}, {params, grants}, ...]}
+ *       Where last entry is the current parameters and role-scope patterns,
+ *       this way the UI could be augmented to list old grants and facilitate
+ *       easy upgrades to the newest pattern; even if new parameters are
+ *       introduced.
+ *
+ * Note: Even with the above addition, there is still a slight risk of people
+ *       inconsistencies if one scope-role pattern is a strict subset of another
+ *       and the grant is revoked using the wrong UI.
+ */
+export default [
+  // READ ABOVE BEFORE MAKING CHANGES
+  {
+    name: 'authorize-github-organizations',
+    icon: 'github',
+    title: 'Authorize Github Organizations',
+    description: `
+Authorize **all** repositories under a github organization to use taskcluster.
+
+By default any the tascluster-github application can be installed on any github
+organization/repository. However, github repositories are not granted any scopes
+by default, so even if the repository contains have a \`.taskcluster.yml\`,
+tasks won't be triggered.
+
+To make it easy to get started with a new github organization, this pattern
+grants \`assume:project:taskcluster:mozilla-github-repository\` to all
+repositories under a given organization. This role grants the repositories a
+reasonable set of low-privileged scopes to get people started.
+    `,
+    params: {
+      organization: /^[a-zA-Z0-9_-]+$/
+    },
+    grants: {
+      'repo:github.com/<organization>/*': [
+        'assume:project:taskcluster:mozilla-github-repository'
+      ]
+    }
+  }
+];


### PR DESCRIPTION
This is the scope-grant tool I was talking about...

 * Patterns are easy to read, see `patterns.js`; adding new ones are easy too,
 * This far more robust than manually copy/pasting role-scope patterns we've agreed on,
 * This tool can list existing instantiations of selected pattern
   (this is done by substituting the regular expressions for the parameters into the role/scope-patterns and matching them against the existing roles; yes, it's complicated xcrossproduct magic..)

Some screenshots:  
 * https://screenshots.firefox.com/YVkSJBVTq17tyzV1/localhost
 * https://screenshots.firefox.com/f9ws1ZgBAqacO0zQ/localhost
 * https://screenshots.firefox.com/6QxiUhyNZuaY5Mzj/localhost

I hope this can become a good way to document the role-scope patterns we use.
I deliberately keep any scripting away from `patterns.js`, so that the patterns are strictly declarative.

Immediate use-cases:
 * Project creation,
 * Authorization of github repositories,
 * Setting up the correct role for a new workerType,
 * Granting project ownership to an LDAP group,

Over time I think we could end up with many more...
@djmitche, I think this could be used to define projects... I agree with your concerns regarding updating the patterns, I've outlined a possible solution in `patterns.js` along with a warning against modifing patterns...

@eliperelman, I recognize that the `ScopeGrants` component is a but clumpsy, and maybe in some future we refactor it to a few sub-components.. But I don't want to over-engineer this before we have thought a bit more about how we want to solve the problem with modified patterns...