### PR TITLE
Update client data when resetting access token

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import { fromNowJSON } from 'taskcluster-client-web';
-import { omit } from 'ramda';
+import { omit, identity, of, T, cond } from 'ramda';
 import merge from 'deepmerge';
 import cloneDeep from 'lodash.clonedeep';
 import Loadable from 'react-loadable';
@@ -96,6 +96,9 @@ export const parameterizeTask = task =>
       })
     }
   );
+
+// toArray :: a -> Array
+export const toArray = cond([[Array.isArray, identity], [T, of]]);
 
 export const labels = {
   running: 'primary',

--- a/src/views/ClientCreator/ClientCreator.js
+++ b/src/views/ClientCreator/ClientCreator.js
@@ -7,6 +7,7 @@ import { scopeIntersection } from 'taskcluster-lib-scopes';
 import Error from '../../components/Error';
 import Spinner from '../../components/Spinner';
 import ClientEditor from './ClientEditor';
+import { toArray } from '../../utils';
 import styles from './styles.css';
 
 export default class ClientCreator extends React.PureComponent {
@@ -39,10 +40,7 @@ export default class ClientCreator extends React.PureComponent {
         const description =
           this.state.query.description ||
           `Client created ${new Date()} for ${this.state.query.callback_url}`;
-        const { scope } = this.state.query;
-        const scopes = (typeof scope === 'string' ? [scope] : scope).filter(
-          s => s
-        );
+        const scopes = toArray(this.state.query.scope);
 
         await this.props.auth.updateClient(this.state.client.clientId, {
           description,
@@ -103,8 +101,7 @@ export default class ClientCreator extends React.PureComponent {
       this.state.query.description ||
       `Client created ${new Date()} for ${this.state.query.callback_url}`;
     const clientId = await this.nextAvailableClientId(clientName, 0);
-    const { scope } = this.state.query;
-    const scopes = (typeof scope === 'string' ? [scope] : scope).filter(s => s);
+    const scopes = toArray(this.state.query.scope);
 
     return {
       clientId,


### PR DESCRIPTION
If a user decides to reset the access token, the client gets a new token but all other parameters provided in the login query (expires, description, scopes) are presently being neglected. This pull-requests updates the client prior to calling the callback.