### PR TITLE
Fetch client prefix before loading the client

### DIFF
--- a/src/views/ClientCreator/ClientCreator.js
+++ b/src/views/ClientCreator/ClientCreator.js
@@ -29,8 +29,8 @@ export default class ClientCreator extends React.PureComponent {
     this.loadClient(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.loadClientPrefix(nextProps.userSession);
+  async componentWillReceiveProps(nextProps) {
+    await this.loadClientPrefix(nextProps.userSession);
     this.loadClient(nextProps);
   }
 


### PR DESCRIPTION
Presently, on mount, the component is loading the client before even
having the time to fetch the client prefix. As a consequence, Tools will
think that it's dealing with a new client, hence providing the client editor.
If the client exists, then they should be prompted with the view of
either resetting the access token or creating a new client. `componentWillMount`
does it well, but `componentWillReceiveProps` fails to await.