### PR TITLE
Possible fix for taskcluster signin

### DIFF
--- a/src/views/ClientCreator/ClientCreator.js
+++ b/src/views/ClientCreator/ClientCreator.js
@@ -139,7 +139,7 @@ export default class ClientCreator extends React.PureComponent {
   }
 
   async loadClient({ userSession, auth }) {
-    if (!userSession) {
+    if (!userSession || !this.state.clientPrefix) {
       return;
     }
 


### PR DESCRIPTION
There seems to be a regression. Clicking on "Development Sign-in" redirects to the create new client editor view and appends the "-1" to the clientId. This behavior is not wanted. The "-1" at the end of the clientId should only happen when a user chooses not to reset the token. It's currently hard to debug since the development sign-in redirect you to the tools production website (no longer on localhost). I'm hoping this would fix the issue but it's hard to know without having it merged first.