### PR TITLE
Throw a better error message when not logged in

### DIFF
--- a/src/views/Provisioners/Provisioners.js
+++ b/src/views/Provisioners/Provisioners.js
@@ -104,7 +104,10 @@ export default class Provisioners extends React.PureComponent {
 
     this.setState({ actionLoading: true }, async () => {
       try {
-        const credentials = await this.props.userSession.getCredentials();
+        const credentials =
+          (this.props.userSession &&
+            (await this.props.userSession.getCredentials())) ||
+          {};
 
         await request(url, {
           extra: this.props.queue.buildExtraData(credentials),

--- a/src/views/WorkerManager/WorkerManager.js
+++ b/src/views/WorkerManager/WorkerManager.js
@@ -175,7 +175,10 @@ export default class WorkerManager extends React.PureComponent {
 
     this.setState({ actionLoading: true }, async () => {
       try {
-        const credentials = await this.props.userSession.getCredentials();
+        const credentials =
+          (this.props.userSession &&
+            (await this.props.userSession.getCredentials())) ||
+          {};
 
         await request(url, {
           extra: this.props.queue.buildExtraData(credentials),

--- a/src/views/Workers/WorkerManager.js
+++ b/src/views/Workers/WorkerManager.js
@@ -148,7 +148,10 @@ export default class WorkerManager extends React.PureComponent {
 
     this.setState({ actionLoading: true }, async () => {
       try {
-        const credentials = await this.props.userSession.getCredentials();
+        const credentials =
+          (this.props.userSession &&
+            (await this.props.userSession.getCredentials())) ||
+          {};
 
         await request(url, {
           extra: this.props.queue.buildExtraData(credentials),


### PR DESCRIPTION
Terminating an instance for example without being logged throws an error of "this.props.userSession is null" rather than inform the user to login first.

This pull-request handles the error better. The error message when I try to terminate an instance when running the tools site locally and not logged in is now:

![screen shot 2017-12-05 at 12 35 06 pm](https://user-images.githubusercontent.com/3766511/33621687-9e0c9e8a-d9b9-11e7-9da7-3a6bca0316b6.png)
