### PR TITLE
Set default GitHub events for Quick Start tool

### DIFF
--- a/src/views/QuickStart/index.js
+++ b/src/views/QuickStart/index.js
@@ -88,18 +88,22 @@ const cmdDirectory = (type, org = '<YOUR_ORG>', repo = '<YOUR_REPO>') =>
 const githubClient = new Github({});
 
 export default class YamlCreator extends React.Component {
+  static initialState = {
+    resetActive: false,
+    tasks: [],
+    events: new Set(),
+    taskName: '',
+    taskDescription: ''
+  };
+
   constructor(props) {
     super(props);
     this.state = {
-      tasks: [],
-      events: new Set(),
+      ...YamlCreator.initialState,
       image: 'node',
       commands: cmdDirectory('node'),
       currentCmd: cmdDirectory('node'),
       displayCmds: true,
-      taskName: '',
-      taskDescription: '',
-      resetActive: false,
       owner: '',
       repo: '',
       installedState: null,
@@ -155,14 +159,9 @@ export default class YamlCreator extends React.Component {
       commands: e.target.value === 'standard' ? this.state.commands : []
     });
 
-  resetAll = () =>
-    this.setState({
-      resetActive: false,
-      tasks: [],
-      events: new Set(),
-      taskName: '',
-      taskDescription: ''
-    });
+  resetAll = () => {
+    this.setState(YamlCreator.initialState);
+  };
 
   renderEditor() {
     const newYaml = safeDump({

--- a/src/views/QuickStart/index.js
+++ b/src/views/QuickStart/index.js
@@ -99,12 +99,6 @@ export default class YamlCreator extends React.Component {
       displayCmds: true,
       taskName: '',
       taskDescription: '',
-      pullRequestOpened: false,
-      pullRequestClosed: false,
-      pullRequestSynchronized: false,
-      pullRequestReopened: false,
-      pushMade: false,
-      releaseMade: false,
       resetActive: false,
       owner: '',
       repo: '',
@@ -134,8 +128,7 @@ export default class YamlCreator extends React.Component {
       : events.add(event.target.name);
 
     this.setState({
-      events: [...events],
-      [event.target.id]: !this.state[event.target.id],
+      events,
       resetActive: true
     });
   };
@@ -168,13 +161,7 @@ export default class YamlCreator extends React.Component {
       tasks: [],
       events: new Set(),
       taskName: '',
-      taskDescription: '',
-      pullRequestOpened: false,
-      pullRequestClosed: false,
-      pullRequestSynchronized: false,
-      pullRequestReopened: false,
-      pushMade: false,
-      releaseMade: false
+      taskDescription: ''
     });
 
   renderEditor() {
@@ -192,7 +179,7 @@ export default class YamlCreator extends React.Component {
             },
             extra: {
               github: {
-                events: [...this.state.events]
+                events: [...this.state.events].sort()
               }
             },
             payload: {
@@ -382,49 +369,43 @@ export default class YamlCreator extends React.Component {
               <ControlLabel>This task should run when:</ControlLabel>
               <Checkbox
                 name="pull_request.opened"
-                id="pullRequestOpened"
                 className="data_checkboxes"
-                checked={this.state.pullRequestOpened}
+                checked={this.state.events.has('pull_request.opened')}
                 onChange={this.handleEventsSelection}>
                 Pull request opened
               </Checkbox>
               <Checkbox
                 name="pull_request.closed"
-                id="pullRequestClosed"
                 className="data_checkboxes"
-                checked={this.state.pullRequestClosed}
+                checked={this.state.events.has('pull_request.closed')}
                 onChange={this.handleEventsSelection}>
                 Pull request merged or closed
               </Checkbox>
               <Checkbox
                 name="pull_request.synchronize"
-                id="pullRequestSynchronized"
                 className="data_checkboxes"
-                checked={this.state.pullRequestSynchronized}
+                checked={this.state.events.has('pull_request.synchronize')}
                 onChange={this.handleEventsSelection}>
                 New commit made in an opened pull request
               </Checkbox>
               <Checkbox
                 name="pull_request.reopened"
-                id="pullRequestReopened"
                 className="data_checkboxes"
-                checked={this.state.pullRequestReopened}
+                checked={this.state.events.has('pull_request.reopened')}
                 onChange={this.handleEventsSelection}>
                 Pull request re-opened
               </Checkbox>
               <Checkbox
                 name="push"
-                id="pushMade"
                 className="data_checkboxes"
-                checked={this.state.pushMade}
+                checked={this.state.events.has('push')}
                 onChange={this.handleEventsSelection}>
                 Push
               </Checkbox>
               <Checkbox
                 name="release"
-                id="releaseMade"
                 className="data_checkboxes"
-                checked={this.state.releaseMade}
+                checked={this.state.events.has('release')}
                 onChange={this.handleEventsSelection}>
                 Release or tag created
               </Checkbox>

--- a/src/views/QuickStart/index.js
+++ b/src/views/QuickStart/index.js
@@ -91,7 +91,11 @@ export default class YamlCreator extends React.Component {
   static initialState = {
     resetActive: false,
     tasks: [],
-    events: new Set(),
+    events: new Set([
+      'pull_request.opened',
+      'pull_request.reopened',
+      'pull_request.synchronize'
+    ]),
     taskName: '',
     taskDescription: ''
   };


### PR DESCRIPTION
This ensures .taskcluster.yml files generated with the quick start tool
actually cause Taskcluster jobs to be triggered,
instead of seeming to not do anything.

Because the current job discoverability story is not great
(best way to find jobs is via GitHub status checks),
this should help reduce confusion for newcomers to TaskCluster.