### PR TITLE
Avoid automatically changing working dir, git state

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "neutrino lint --fix",
-      "git add"
+      "neutrino lint"
     ]
   },
   "repository": "taskcluster/taskcluster-tools",


### PR DESCRIPTION
Having a pre-commit lint hook is great,
but the current setup that automatically changes working directory
files and does a raw git add was surprising to me.

Additionally, this is incompatible with any workflow that uses the git
staging area, which I tend to do a lot.

I was surprised that the hooks for my local git repo were mutated by
husky (via yarn), but using this for linting seems OK for now.
In the future, I would prefer to have a one-line command to
enable/install hooks instead of having them automatically configured.