### PR TITLE
Fix issue where dependencies aren't shown

### DIFF
--- a/src/views/UnifiedInspector/TaskDetails.js
+++ b/src/views/UnifiedInspector/TaskDetails.js
@@ -49,6 +49,12 @@ export default class TaskDetails extends React.PureComponent {
     }
   }
 
+  componentWillMount() {
+    if (this.props.task && this.props.task.dependencies.length) {
+      this.loadDependencies(this.props.task.dependencies);
+    }
+  }
+
   componentWillReceiveProps({ task }) {
     if (!this.props.task && task) {
       this.loadDependencies(task.dependencies);


### PR DESCRIPTION
Navigating directly to the details page of a task ID properly shows the
list of dependencies in the UI. However, clicking on one of
those tasks then navigating to the details page may show an empty list
of dependencies.

Presently, the logic behind loading the dependencies sits under
`componentWillReceiveProps`. This works when you load a URL directly
but when you navigate to it from the "Run Logs" tab for example,
`componentWillReceiveProps` will not trigger since we are dealing
with the same task. To solve that issue, when we have the task,
we can take care of the loading part in `componentWillMount`.