### PR TITLE
Rendering worker type pending tasks differently depending on error or no value

### DIFF
--- a/src/views/AwsProvisioner/WorkerTypeRow.js
+++ b/src/views/AwsProvisioner/WorkerTypeRow.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { string, shape, number, bool, func } from 'prop-types';
 import { OverlayTrigger, ProgressBar, Tooltip } from 'react-bootstrap';
+import Icon from 'react-fontawesome';
 
 export default class WorkerTypeRow extends React.Component {
   static propTypes = {
@@ -157,7 +158,15 @@ export default class WorkerTypeRow extends React.Component {
     const { error, pendingTasks } = this.state;
 
     if (error) {
-      return <span style={{ color: '#f00' }}>*</span>;
+      const tooltip = (
+        <Tooltip id={'worker-type-row-loading-error'}>{error.message}</Tooltip>
+      );
+
+      return (
+        <OverlayTrigger placement="left" overlay={tooltip}>
+          <Icon name="exclamation-circle" />
+        </OverlayTrigger>
+      );
     }
 
     if (pendingTasks == null || pendingTasks.pendingTasks == null) {

--- a/src/views/AwsProvisioner/WorkerTypeRow.js
+++ b/src/views/AwsProvisioner/WorkerTypeRow.js
@@ -21,7 +21,7 @@ export default class WorkerTypeRow extends React.Component {
     super(props);
 
     this.state = {
-      pendingTasks: { pendingTasks: 0 },
+      pendingTasks: { pendingTasks: null },
       error: null
     };
   }
@@ -154,15 +154,17 @@ export default class WorkerTypeRow extends React.Component {
   }
 
   renderState() {
-    if (this.state.error) {
-      return <span />;
+    const { error, pendingTasks } = this.state;
+
+    if (error) {
+      return <span style={{ color: '#f00' }}>*</span>;
     }
 
-    if (!this.state.pendingTasks) {
-      return <span>...</span>;
+    if (pendingTasks == null || pendingTasks.pendingTasks == null) {
+      return <span>-</span>;
     }
 
-    return this.state.pendingTasks.pendingTasks;
+    return <span>{pendingTasks.pendingTasks}</span>;
   }
 
   render() {


### PR DESCRIPTION
I randomly faked the errors from some responses so you could see how it would look.

Loading stats (ignore the error stars, they will all have dashes):

<img width="1680" alt="screen shot 2018-01-19 at 3 39 23 pm" src="https://user-images.githubusercontent.com/285899/35172910-2b6725aa-fd2f-11e7-903e-bc3f95704e26.png">

Stats with errors:

<img width="1680" alt="screen shot 2018-01-19 at 3 39 32 pm" src="https://user-images.githubusercontent.com/285899/35172916-2ec25c10-fd2f-11e7-9856-cb44f304d80e.png">
