### PR TITLE
Bump maxRunTime of default task to avoid it unnecessarily failing

### DIFF
--- a/src/views/TaskCreator/TaskCreator.js
+++ b/src/views/TaskCreator/TaskCreator.js
@@ -25,7 +25,8 @@ const defaultTask = {
       '-c',
       'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
     ],
-    maxRunTime: 60 * 10
+    // 30s margin to avoid task timeout winning race against task command.
+    maxRunTime: 600 + 30
   },
   metadata: {
     name: 'Example Task',


### PR DESCRIPTION
See e.g. [task UHYGfJHgTpKuQyjUGw3Srg](https://tools.taskcluster.net/groups/H7x2f27_TzyOHizJBYc5zQ/tasks/UHYGfJHgTpKuQyjUGw3Srg/runs/0/logs/public%2Flogs%2Flive.log).