### PR TITLE
Bug 1402823 - In taskcluster github quickstart, commands not shown in code field if 'clone repo and run my tests' is selected after 'I will define them myself'

### DIFF
--- a/src/views/QuickStart/index.js
+++ b/src/views/QuickStart/index.js
@@ -160,7 +160,8 @@ export default class YamlCreator extends React.Component {
     this.setState({
       displayCmds: e.target.value === 'standard',
       currentCmd: this.state.commands,
-      commands: e.target.value === 'standard' ? this.state.commands : []
+      commands:
+        e.target.value === 'standard' ? cmdDirectory(this.state.image) : []
     });
 
   resetAll = () => {


### PR DESCRIPTION
In taskcluster github quickstart, commands not shown in code field if 'clone repo and run my tests' is selected after 'I will define them myself'