### PR TITLE
Do not log user out if multiple tabs try to renew token

### DIFF
--- a/src/auth/AuthController.js
+++ b/src/auth/AuthController.js
@@ -113,7 +113,6 @@ export default class AuthController {
         await auth0Renew({ userSession, authController: this });
       }
     } catch (err) {
-      this.setUserSession(null);
       // usually this is just "user interaction required" or the like, but just
       // in case the user wants to peek, put it in the console
       /* eslint-disable no-console */


### PR DESCRIPTION
gerard-majax on IRC:

> is it normal that I get disconnected from taskcluster/auth0 often?
like I signed in this afternoon, and now I'm again signed off

This is probably the same thing that happened with https://bugzilla.mozilla.org/show_bug.cgi?id=1437824. This commit does not log user out if renew fails in case:
* multiple tabs are trying to renew at the same time, where one
   tab will throw an error hence logging users out
* the renewal fails for transient reasons (eg wifi not re-established
  after machine resumes from sleep)