### PR TITLE
Bug 1438893 - Code editor warning icon

### DIFF
--- a/src/components/CodeEditor/index.js
+++ b/src/components/CodeEditor/index.js
@@ -56,7 +56,7 @@ CodeEditor.propTypes = {
 CodeEditor.defaultProps = {
   lineNumbers: true,
   textAreaClassName: 'form-control',
-  gutter: ['CodeMirror-lint-markers'],
+  gutters: ['CodeMirror-lint-markers'],
   indentWithTabs: false,
   tabSize: 2,
   textAreaStyle: { minHeight: '20em' }

--- a/src/views/SecretsManager/SecretEditor.js
+++ b/src/views/SecretsManager/SecretEditor.js
@@ -153,7 +153,6 @@ export default class SecretEditor extends React.PureComponent {
     if (editing) {
       return (
         <CodeEditor
-          gutters={['CodeMirror-lint-markers']}
           lint={true}
           mode="yaml"
           value={secretValue}

--- a/src/views/TaskCreator/TaskCreator.js
+++ b/src/views/TaskCreator/TaskCreator.js
@@ -172,7 +172,6 @@ export default class TaskCreator extends React.PureComponent {
     return (
       <div>
         <CodeEditor
-          gutters={['CodeMirror-lint-markers']}
           mode="yaml"
           lint={true}
           value={task}


### PR DESCRIPTION
[CodeEditor](https://github.com/taskcluster/taskcluster-tools/blob/master/src/components/CodeEditor/index.js) already have a `defaultProps` with gutters defined. I just fixed a typo.

Besides the [ScopeEditor](https://github.com/taskcluster/taskcluster-tools/blob/master/src/components/ScopeEditor/index.js) this patch may affect the [TriggerButton.js](https://github.com/taskcluster/taskcluster-tools/blob/master/src/views/HooksManager/TriggerButton.js) and [ActionsMenu.js](https://github.com/taskcluster/taskcluster-tools/blob/master/src/views/UnifiedInspector/ActionsMenu.js) files because the `lint={true}` config it is set. I did not figured out how to test them.

Referred: [Bug 1438893](https://bugzilla.mozilla.org/show_bug.cgi?id=1438893)