### PR TITLE
Bug 1438879 - Remove unnecessary spinner icons in Index Browser

### DIFF
--- a/src/components/IndexBrowser/index.js
+++ b/src/components/IndexBrowser/index.js
@@ -100,12 +100,6 @@ export default class IndexBrowser extends React.PureComponent {
     );
   };
 
-  renderSpinner() {
-    if (!this.state.namespaces && !this.state.tasks) {
-      return <Spinner />;
-    }
-  }
-
   renderBreadcrumbs() {
     const { namespace, urlRoot } = this.props;
     const parents = namespace.split('.');
@@ -252,9 +246,14 @@ export default class IndexBrowser extends React.PureComponent {
               </div>
             </FormGroup>
           </form>
-          {this.renderSpinner()}
-          {this.renderTasks()}
-          {this.renderNamespaces()}
+          {this.state.tasks && this.state.namespaces ? (
+            <div>
+              {this.renderTasks()}
+              {this.renderNamespaces()}
+            </div>
+          ) : (
+            <Spinner />
+          )}
         </Col>
         <Col md={6}>{this.props.children}</Col>
       </Row>

--- a/src/components/IndexBrowser/index.js
+++ b/src/components/IndexBrowser/index.js
@@ -100,6 +100,12 @@ export default class IndexBrowser extends React.PureComponent {
     );
   };
 
+  renderSpinner() {
+    if (!this.state.namespaces && !this.state.tasks) {
+      return <Spinner />;
+    }
+  }
+
   renderBreadcrumbs() {
     const { namespace, urlRoot } = this.props;
     const parents = namespace.split('.');
@@ -125,10 +131,6 @@ export default class IndexBrowser extends React.PureComponent {
   }
 
   renderNamespaces() {
-    if (!this.state.namespaces) {
-      return <Spinner />;
-    }
-
     const tableStyle = { borderTop: 'none', borderBottom: '1px solid #ddd' };
 
     return (
@@ -171,11 +173,6 @@ export default class IndexBrowser extends React.PureComponent {
 
   renderTasks() {
     const { namespace, urlRoot } = this.props;
-
-    if (!this.state.tasks) {
-      return <Spinner />;
-    }
-
     const tableStyle = { borderTop: 'none', borderBottom: '1px solid #ddd' };
 
     return (
@@ -255,6 +252,7 @@ export default class IndexBrowser extends React.PureComponent {
               </div>
             </FormGroup>
           </form>
+          {this.renderSpinner()}
           {this.renderTasks()}
           {this.renderNamespaces()}
         </Col>


### PR DESCRIPTION
When [IndexBrowser](https://github.com/taskcluster/taskcluster-tools/tree/master/src/components/IndexBrowser) loads, two spinners show up, one for `namespace` and one for `tasks`.

Create a function to capture the change in state of each as a single item. This will allow the [Spinner](https://github.com/taskcluster/taskcluster-tools/blob/master/src/components/Spinner/index.js) to load once only.

Reference: [Bug1438879](https://bugzilla.mozilla.org/show_bug.cgi?id=1438879)