### PR TITLE
Bug 1436028 - do not show expandedScopes for * roles

### DIFF
--- a/src/components/RoleEditor/index.js
+++ b/src/components/RoleEditor/index.js
@@ -294,7 +294,10 @@ export default class RoleEditor extends React.PureComponent {
               />
             </div>
           </div>
-          {!isEditing && !isCreating && this.state.role.expandedScopes ? (
+          {!isEditing &&
+          !isCreating &&
+          this.state.role.expandedScopes &&
+          !this.state.role.roleId.endsWith('*') ? (
             <div className="form-group">
               <label className="control-label col-md-3">Expanded Scopes</label>
               <div className="col-md-9">


### PR DESCRIPTION
These expanded scopes confuse people all the time.

This doesn't fix the bug, but will at least avoid the confusion while we fix it.