### PR TITLE
bug 1317289 scope error displayed after signing in under certain circumstances

### DIFF
--- a/src/views/AwsProvisioner/WorkerTypeView.js
+++ b/src/views/AwsProvisioner/WorkerTypeView.js
@@ -8,6 +8,7 @@ import Code from '../../components/Code';
 import WorkerTypeEditor from './WorkerTypeEditor';
 import WorkerTypeResources from './WorkerTypeResources';
 import WorkerTypeStatus from './WorkerTypeStatus';
+import UserSession from '../../auth/UserSession';
 
 export default class WorkerTypeView extends React.PureComponent {
   static propTypes = {
@@ -37,9 +38,14 @@ export default class WorkerTypeView extends React.PureComponent {
   componentWillReceiveProps(nextProps) {
     if (
       nextProps.workerType !== this.props.workerType ||
-      nextProps.provisionerId !== this.props.provisionerId
+      nextProps.provisionerId !== this.props.provisionerId ||
+      UserSession.userChanged(this.props.userSession, nextProps.userSession)
     ) {
-      this.loadWorkerType(nextProps);
+      if (this.state.error) {
+        this.setState({ error: null }, () => this.loadWorkerType(nextProps));
+      } else {
+        this.loadWorkerType(nextProps);
+      }
     }
   }
 


### PR DESCRIPTION
# Fix error message not clearing and GET call not invoking on user session change
## Technical findings for Bug 1317289

1. The root cause for the bug is in the “componentWillReceiveProps” method in the “WorkerTypeView” component found in “src/views/AwsProvisioner/WorkerTypeView.js”

2. This is the root cause for “loadWorkerType” GET call for the worker type is not executed when a user session changes. Also, note that the GET call is only executed if “provisionerId” or “workerType” type changes. Moreover, there is no clearing of the error in “this.state”.

## Fix details

1. We can use “UserSession.userChanged(this.props.userSession, nextProps.userSession)” to check if the user session changes. We can add this as an additional OR condition for the if check in “componentWillReceiveProps” of “WorkerTypeView”. This ensures the GET call is fired when the user session changes.
2. To ensure the state error is cleared, we need to add “this.setState({ error: null });”. However, clearing this every time would cause an additional re-render of the “WorkerTypeView” component. We only need to clear the error if it is not null already. If state error is present, we first clear it allowing the spinner to be shown while the GET call is run, and in the callback of setState we invoke “loadWorkerType” GET call. If state error is not present we just invoke the “loadWorkerType” GET call without calling setState.



