### PR TITLE
Bug 1436115 solved - Scope editor should not highlight '*' if it is n…

### DIFF
--- a/src/components/ScopeEditor/scopemode.js
+++ b/src/components/ScopeEditor/scopemode.js
@@ -23,7 +23,7 @@ CodeMirror.registerHelper('lint', 'scopemode', text =>
 
 CodeMirror.defineSimpleMode('scopemode', {
   start: [
-    { regex: /\*/, token: 'star' },
+    { regex: /\*($|(\s+))/, token: 'star' },
     { regex: /:/, token: 'sep' },
     { regex: /\//, token: 'slash' },
     { regex: /<\.>/, token: 'mistake-param' },


### PR DESCRIPTION
Bug 1436115 solved - Scope editor should not highlight '*' if it is not the last character in the scope.