### PR TITLE
Bug 1441648 - Remove error box from Worker Explorer after authentication

### DIFF
--- a/src/views/WorkerManager/WorkerManager.js
+++ b/src/views/WorkerManager/WorkerManager.js
@@ -17,6 +17,7 @@ import Breadcrumb from '../../components/Breadcrumb';
 import Snackbar from '../../components/Snackbar';
 import Error from '../../components/Error';
 import Spinner from '../../components/Spinner';
+import UserSession from '../../auth/UserSession';
 import SearchForm from './SearchForm';
 import WorkerTable from './WorkerTable';
 import styles from './styles.css';
@@ -49,6 +50,14 @@ export default class WorkerManager extends React.PureComponent {
     }
 
     this.loadProvisioners();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      UserSession.userChanged(this.props.userSession, nextProps.userSession)
+    ) {
+      this.setState({ error: null });
+    }
   }
 
   async loadProvisioners(token) {


### PR DESCRIPTION
This import the `UserSession` component and add the `componentWillReceiveProps()` method to verify if the user state has changed. If so, it update the state by removing the error box.

Referred: [Bug 1441648](https://bugzilla.mozilla.org/1441648)