### PR TITLE
Bug 1441615 - Hooks Editor: clicking on create hook while logged out

### DIFF
--- a/src/views/HooksManager/HookEditView.jsx
+++ b/src/views/HooksManager/HookEditView.jsx
@@ -35,7 +35,7 @@ export default class HookEditView extends PureComponent {
       nextProps.hookId !== this.props.hookId
     ) {
       this.loadHook(nextProps);
-    }
+    } else this.dismissError();
   }
 
   async loadHook({ hookGroupId, hookId, hooks }) {

--- a/src/views/HooksManager/HookEditView.jsx
+++ b/src/views/HooksManager/HookEditView.jsx
@@ -1,7 +1,6 @@
 import { PureComponent } from 'react';
 import { string, func } from 'prop-types';
 import { omit } from 'ramda';
-import { Alert } from 'react-bootstrap';
 import Spinner from '../../components/Spinner';
 import HookEditor from './HookEditor';
 import HookDisplay from './HookDisplay';
@@ -35,7 +34,9 @@ export default class HookEditView extends PureComponent {
       nextProps.hookId !== this.props.hookId
     ) {
       this.loadHook(nextProps);
-    } else this.dismissError();
+    } else {
+      this.handleDismissError();
+    }
   }
 
   async loadHook({ hookGroupId, hookId, hooks }) {
@@ -148,17 +149,7 @@ export default class HookEditView extends PureComponent {
 
   render() {
     const { hookGroupId, hookId } = this.props;
-    const { error, editing, hook, hookStatus } = this.state;
-
-    if (error) {
-      return (
-        <Alert bsStyle="danger" onDismiss={this.handleDismissError}>
-          <strong>Error executing operation</strong>
-          <br />
-          {error.toString()}
-        </Alert>
-      );
-    }
+    const { editing, hook, hookStatus } = this.state;
 
     if (!hook && (hookGroupId && hookId)) {
       return <Spinner />;
@@ -176,6 +167,8 @@ export default class HookEditView extends PureComponent {
           onCreateHook={this.handleCreateHook}
           onUpdateHook={this.handleUpdateHook}
           onDeleteHook={this.handleDeleteHook}
+          error={this.state.error}
+          onError={this.handleDismissError}
         />
       );
     }

--- a/src/views/HooksManager/HookEditor.jsx
+++ b/src/views/HooksManager/HookEditor.jsx
@@ -1,6 +1,6 @@
 import { PureComponent } from 'react';
 import { string, bool, object, func } from 'prop-types';
-import { Button, Glyphicon, ButtonToolbar } from 'react-bootstrap';
+import { Alert, Button, Glyphicon, ButtonToolbar } from 'react-bootstrap';
 import clone from 'lodash.clonedeep';
 import equal from 'deep-equal';
 import { assocPath } from 'ramda';
@@ -45,10 +45,12 @@ export default class HookEditor extends PureComponent {
     currentHookId: string,
     currentHookGroupId: string,
     hook: object,
+    error: object,
     isCreating: bool,
     onCreateHook: func.isRequired,
     onUpdateHook: func.isRequired,
-    onDeleteHook: func.isRequired
+    onDeleteHook: func.isRequired,
+    onError: func.isRequired
   };
 
   constructor(props) {
@@ -279,6 +281,16 @@ export default class HookEditor extends PureComponent {
   render() {
     const { isCreating, hookGroupId, hookId } = this.props;
     const { hook } = this.state;
+
+    if (this.props.error) {
+      return (
+        <Alert bsStyle="danger" onDismiss={this.props.onError}>
+          <strong>Error executing operation</strong>
+          <br />
+          {this.props.error.toString()}
+        </Alert>
+      );
+    }
 
     if (!hook) {
       return null;


### PR DESCRIPTION
Hooks Editor: clicking on create hook while logged out will make you lose your form.

Whenever User session is changed, React does forceupdate() of all the components but earlier error status wasn't getting updated upon re-rendering. This change allows error to be reset to null on user login while other fields in the editor retain their data. 

As this cannot be checked by running it on the local server, I request the maintainers to please try review the change.