### PR TITLE
Bug 1442292 - Remove modal typo from Scope Grants

### DIFF
--- a/src/views/ScopeGrants/ScopeGrants.js
+++ b/src/views/ScopeGrants/ScopeGrants.js
@@ -299,7 +299,7 @@ export default class ScopeGrants extends React.PureComponent {
           onComplete={this.handleReload}
           body={
             <span>
-              Are you sure you want to <strong>remove scope grants</strong>
+              Are you sure you want to <strong>remove scope grants </strong>
               from role?
               <br />
               <br />


### PR DESCRIPTION
Fix a minor typo.

Referred: [Bug 1442292](https://bugzilla.mozilla.org/1442292)