### PR TITLE
Bug1442237 Make Scope Grants have multiple views

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -269,7 +269,7 @@ export default class App extends Component {
                   component={ScopeInspector}
                 />
                 <PropsRoute
-                  path="/auth/grants/:pattern?"
+                  path="/auth/grants/:pattern?/:organization?"
                   component={ScopeGrants}
                 />
                 <PropsRoute

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -67,12 +67,14 @@ export default class ScopeGrants extends PureComponent {
 
   handleGrantsRedirect = () => this.props.history.push(`/auth/grants`);
   handleNewGrant = () => this.setState({ selected: null, args: {} });
-  selectGrant = org => {
+  handleNavigate = org => {
     const { history, pattern } = this.props;
 
     if (org === 'create') {
       this.handleNewGrant();
       history.push(`/auth/grants/${pattern}/create`);
+    } else if (org === 'pattern') {
+      history.push(`/auth/grants/${pattern}`);
     } else {
       history.push(`/auth/grants/${pattern}/${encodeURIComponent(org)}`);
     }
@@ -127,7 +129,7 @@ export default class ScopeGrants extends PureComponent {
                           role="gridcell"
                           onClick={() => {
                             this.setState({ selected: args });
-                            this.selectGrant(args[param]);
+                            this.handleNavigate(args[param]);
                           }}>
                           <code>{args[param]}</code>
                         </td>
@@ -137,7 +139,7 @@ export default class ScopeGrants extends PureComponent {
                 </tbody>
               </Table>
               <hr />
-              <Button onClick={() => this.selectGrant('create')}>
+              <Button onClick={() => this.handleNavigate('create')}>
                 <Glyphicon glyph="plus" /> New Grant
               </Button>
               <br />
@@ -187,6 +189,7 @@ export default class ScopeGrants extends PureComponent {
     const { args } = this.state;
 
     this.setState({ selected: null, roles: null, args: {} });
+    this.handleNavigate('pattern');
     await this.load();
     this.setState({ selected: args });
   };
@@ -257,6 +260,7 @@ export default class ScopeGrants extends PureComponent {
 
   handleReload = () => {
     this.setState({ selected: null, roles: null });
+    this.handleNavigate('pattern');
     this.load();
   };
 
@@ -277,7 +281,7 @@ export default class ScopeGrants extends PureComponent {
   };
 
   renderPatternInstance(pattern, selected) {
-    let args = selected;
+    let arg = selected;
 
     if (this.state.error) {
       return <Error error={this.state.error} />;
@@ -290,11 +294,12 @@ export default class ScopeGrants extends PureComponent {
 
       const instantiatedArgs = instantiatedArguments(pattern, this.state.roles);
 
-      args = instantiatedArgs.find(
-        arg => arg.organization === this.props.organization
+      arg = instantiatedArgs.find(
+        element => element.organization === this.props.organization
       );
     }
 
+    const args = arg;
     const params = Object.keys(pattern.params);
 
     return (

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -181,7 +181,9 @@ export default class ScopeGrants extends PureComponent {
     const { args } = this.state;
 
     this.setState({ selected: null, roles: null, args: {} });
-    this.state.history.push(`/auth/grants/${this.props.pattern}`);
+    this.state.history.replace(
+      `/auth/grants/${this.props.pattern}/${this.props.organization}`
+    );
     await this.load();
     this.setState({ selected: args });
   };
@@ -252,7 +254,7 @@ export default class ScopeGrants extends PureComponent {
 
   handleReload = () => {
     this.setState({ selected: null, roles: null });
-    this.state.history.push(`/auth/grants/${this.props.pattern}`);
+    this.state.history.replace(`/auth/grants/${this.props.pattern}`);
     this.load();
   };
 
@@ -383,7 +385,7 @@ export default class ScopeGrants extends PureComponent {
               key={`pattern-${index}`}
               style={{ textDecoration: 'none', color: 'inherit' }}>
               <ListGroupItem
-                key={`pattern-${index}`}
+                // key={`pattern-${index}`}
                 header={
                   <h3>
                     <Icon name={icon} /> {title}

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -12,6 +12,7 @@ import {
   ControlLabel,
   FormControl
 } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 import { uniq, merge, without, unnest } from 'ramda';
 import Icon from 'react-fontawesome';
 import Error from '../../components/Error';
@@ -65,21 +66,6 @@ export default class ScopeGrants extends PureComponent {
     }
   }
 
-  handleGrantsRedirect = () => this.props.history.push(`/auth/grants`);
-  handleNewGrant = () => this.setState({ selected: null, args: {} });
-  handleNavigate = org => {
-    const { history, pattern } = this.props;
-
-    if (org === 'create') {
-      this.handleNewGrant();
-      history.push(`/auth/grants/${pattern}/create`);
-    } else if (org === 'pattern') {
-      history.push(`/auth/grants/${pattern}`);
-    } else {
-      history.push(`/auth/grants/${pattern}/${encodeURIComponent(org)}`);
-    }
-  };
-
   renderGrants(pattern) {
     if (this.state.error) {
       return <Error error={this.state.error} />;
@@ -98,9 +84,11 @@ export default class ScopeGrants extends PureComponent {
           <HelmetTitle title={pattern.title} />
           <Row>
             <Col md={1}>
-              <Button onClick={this.handleGrantsRedirect}>
-                <Glyphicon glyph="chevron-left" /> Back
-              </Button>
+              <Link to="/auth/grants">
+                <Button>
+                  <Glyphicon glyph="chevron-left" /> Back
+                </Button>
+              </Link>
             </Col>
             <Col md={10}>
               <h2>
@@ -127,11 +115,13 @@ export default class ScopeGrants extends PureComponent {
                         <td
                           key={`params-${index}`}
                           role="gridcell"
-                          onClick={() => {
-                            this.setState({ selected: args });
-                            this.handleNavigate(args[param]);
-                          }}>
-                          <code>{args[param]}</code>
+                          onClick={() => this.setState({ selected: args })}>
+                          <Link
+                            to={`/auth/grants/${
+                              pattern.name
+                            }/${encodeURIComponent(args[param])}`}>
+                            <code>{args[param]}</code>
+                          </Link>
                         </td>
                       ))}
                     </tr>
@@ -139,9 +129,12 @@ export default class ScopeGrants extends PureComponent {
                 </tbody>
               </Table>
               <hr />
-              <Button onClick={() => this.handleNavigate('create')}>
-                <Glyphicon glyph="plus" /> New Grant
-              </Button>
+              <Link to={`/auth/grants/${pattern.name}/create`}>
+                <Button
+                  onClick={() => this.setState({ selected: null, args: {} })}>
+                  <Glyphicon glyph="plus" /> New Grant
+                </Button>
+              </Link>
               <br />
               <br />
             </Col>
@@ -189,7 +182,7 @@ export default class ScopeGrants extends PureComponent {
     const { args } = this.state;
 
     this.setState({ selected: null, roles: null, args: {} });
-    this.handleNavigate('pattern');
+    this.state.history.push(`/auth/grants/${this.props.pattern}`);
     await this.load();
     this.setState({ selected: args });
   };
@@ -260,7 +253,7 @@ export default class ScopeGrants extends PureComponent {
 
   handleReload = () => {
     this.setState({ selected: null, roles: null });
-    this.handleNavigate('pattern');
+    this.state.history.push(`/auth/grants/${this.props.pattern}`);
     this.load();
   };
 

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -184,7 +184,7 @@ export default class ScopeGrants extends PureComponent {
     const { args } = this.state;
 
     this.setState({ selected: null, roles: null, args: {} });
-    this.state.history.replace(
+    this.props.history.replace(
       `/auth/grants/${this.props.pattern}/${this.props.organization}`
     );
     await this.load();
@@ -257,7 +257,7 @@ export default class ScopeGrants extends PureComponent {
 
   handleReload = () => {
     this.setState({ selected: null, roles: null });
-    this.state.history.replace(`/auth/grants/${this.props.pattern}`);
+    this.props.history.replace(`/auth/grants/${this.props.pattern}`);
     this.load();
   };
 

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -12,7 +12,7 @@ import {
   ControlLabel,
   FormControl
 } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
+import { LinkContainer } from 'react-router-bootstrap';
 import { uniq, merge, without, unnest } from 'ramda';
 import Icon from 'react-fontawesome';
 import Error from '../../components/Error';
@@ -84,11 +84,11 @@ export default class ScopeGrants extends PureComponent {
           <HelmetTitle title={pattern.title} />
           <Row>
             <Col md={1}>
-              <Link to="/auth/grants">
+              <LinkContainer exact to="/auth/grants">
                 <Button>
                   <Glyphicon glyph="chevron-left" /> Back
                 </Button>
-              </Link>
+              </LinkContainer>
             </Col>
             <Col md={10}>
               <h2>
@@ -112,28 +112,31 @@ export default class ScopeGrants extends PureComponent {
                   {instantiatedArgs.map((args, index) => (
                     <tr key={`args-${index}`} style={{ cursor: 'pointer' }}>
                       {params.map((param, index) => (
-                        <td key={`params-${index}`} role="gridcell">
-                          <Link
-                            to={`/auth/grants/${
-                              pattern.name
-                            }/${encodeURIComponent(args[param])}`}
-                            onClick={() => this.setState({ selected: args })}>
+                        <LinkContainer
+                          key={`params-${index}`}
+                          exact
+                          to={`/auth/grants/${
+                            pattern.name
+                          }/${encodeURIComponent(args[param])}`}
+                          onClick={() => this.setState({ selected: args })}>
+                          <td role="gridcell">
                             <code>{args[param]}</code>
-                          </Link>
-                        </td>
+                          </td>
+                        </LinkContainer>
                       ))}
                     </tr>
                   ))}
                 </tbody>
               </Table>
               <hr />
-              <Link
+              <LinkContainer
+                exact
                 to={`/auth/grants/${pattern.name}/create`}
                 onClick={() => this.setState({ selected: null, args: {} })}>
                 <Button>
                   <Glyphicon glyph="plus" /> New Grant
                 </Button>
-              </Link>
+              </LinkContainer>
               <br />
               <br />
             </Col>
@@ -380,12 +383,11 @@ export default class ScopeGrants extends PureComponent {
         <br />
         <ListGroup>
           {PATTERNS.map(({ name, title, icon, description }, index) => (
-            <Link
+            <LinkContainer
+              exact
               to={`/auth/grants/${name}`}
-              key={`pattern-${index}`}
-              style={{ textDecoration: 'none', color: 'inherit' }}>
+              key={`pattern-${index}`}>
               <ListGroupItem
-                // key={`pattern-${index}`}
                 header={
                   <h3>
                     <Icon name={icon} /> {title}
@@ -393,7 +395,7 @@ export default class ScopeGrants extends PureComponent {
                 }>
                 <Markdown>{description}</Markdown>
               </ListGroupItem>
-            </Link>
+            </LinkContainer>
           ))}
         </ListGroup>
       </Col>

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -67,7 +67,7 @@ export default class ScopeGrants extends PureComponent {
 
   handleGrantsRedirect = () => this.props.history.push(`/auth/grants`);
   handleNewGrant = () => this.setState({ selected: null, args: {} });
-  select = org => {
+  selectGrant = org => {
     const { history, pattern } = this.props;
 
     if (org === 'create') {
@@ -126,7 +126,7 @@ export default class ScopeGrants extends PureComponent {
                           key={`params-${index}`}
                           onClick={() => {
                             this.setState({ selected: args });
-                            this.select(args[param]);
+                            this.selectGrant(args[param]);
                           }}>
                           <code>{args[param]}</code>
                         </td>
@@ -136,7 +136,7 @@ export default class ScopeGrants extends PureComponent {
                 </tbody>
               </Table>
               <hr />
-              <Button onClick={() => this.select('create')}>
+              <Button onClick={() => this.selectGrant('create')}>
                 <Glyphicon glyph="plus" /> New Grant
               </Button>
               <br />
@@ -275,7 +275,25 @@ export default class ScopeGrants extends PureComponent {
     );
   };
 
-  renderPatternInstance(pattern, args) {
+  renderPatternInstance(pattern, selected) {
+    let args = selected;
+
+    if (this.state.error) {
+      return <Error error={this.state.error} />;
+    }
+
+    if (!selected) {
+      if (!this.state.roles) {
+        return <Spinner />;
+      }
+
+      const instantiatedArgs = instantiatedArguments(pattern, this.state.roles);
+
+      args = instantiatedArgs.find(
+        arg => arg.organization === this.props.organization
+      );
+    }
+
     const params = Object.keys(pattern.params);
 
     return (

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -12,7 +12,7 @@ import {
   ControlLabel,
   FormControl
 } from 'react-bootstrap';
-import { equals, uniq, merge, without, unnest } from 'ramda';
+import { uniq, merge, without, unnest } from 'ramda';
 import Icon from 'react-fontawesome';
 import Error from '../../components/Error';
 import Spinner from '../../components/Spinner';
@@ -110,7 +110,7 @@ export default class ScopeGrants extends PureComponent {
           <hr />
           <Row>
             <Col md={12}>
-              <Table hover>
+              <Table hover role="grid">
                 <thead>
                   <tr>
                     {params.map((param, index) => (
@@ -124,6 +124,7 @@ export default class ScopeGrants extends PureComponent {
                       {params.map((param, index) => (
                         <td
                           key={`params-${index}`}
+                          role="gridcell"
                           onClick={() => {
                             this.setState({ selected: args });
                             this.selectGrant(args[param]);

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -112,14 +112,12 @@ export default class ScopeGrants extends PureComponent {
                   {instantiatedArgs.map((args, index) => (
                     <tr key={`args-${index}`} style={{ cursor: 'pointer' }}>
                       {params.map((param, index) => (
-                        <td
-                          key={`params-${index}`}
-                          role="gridcell"
-                          onClick={() => this.setState({ selected: args })}>
+                        <td key={`params-${index}`} role="gridcell">
                           <Link
                             to={`/auth/grants/${
                               pattern.name
-                            }/${encodeURIComponent(args[param])}`}>
+                            }/${encodeURIComponent(args[param])}`}
+                            onClick={() => this.setState({ selected: args })}>
                             <code>{args[param]}</code>
                           </Link>
                         </td>
@@ -129,9 +127,10 @@ export default class ScopeGrants extends PureComponent {
                 </tbody>
               </Table>
               <hr />
-              <Link to={`/auth/grants/${pattern.name}/create`}>
-                <Button
-                  onClick={() => this.setState({ selected: null, args: {} })}>
+              <Link
+                to={`/auth/grants/${pattern.name}/create`}
+                onClick={() => this.setState({ selected: null, args: {} })}>
+                <Button>
                   <Glyphicon glyph="plus" /> New Grant
                 </Button>
               </Link>
@@ -361,8 +360,6 @@ export default class ScopeGrants extends PureComponent {
     );
   }
 
-  handleOpenPattern = name => this.props.history.push(`/auth/grants/${name}`);
-
   renderPatternSelector() {
     return (
       <Col smOffset={1} sm={10}>
@@ -381,16 +378,20 @@ export default class ScopeGrants extends PureComponent {
         <br />
         <ListGroup>
           {PATTERNS.map(({ name, title, icon, description }, index) => (
-            <ListGroupItem
+            <Link
+              to={`/auth/grants/${name}`}
               key={`pattern-${index}`}
-              header={
-                <h3>
-                  <Icon name={icon} /> {title}
-                </h3>
-              }
-              onClick={() => this.handleOpenPattern(name)}>
-              <Markdown>{description}</Markdown>
-            </ListGroupItem>
+              style={{ textDecoration: 'none', color: 'inherit' }}>
+              <ListGroupItem
+                key={`pattern-${index}`}
+                header={
+                  <h3>
+                    <Icon name={icon} /> {title}
+                  </h3>
+                }>
+                <Markdown>{description}</Markdown>
+              </ListGroupItem>
+            </Link>
           ))}
         </ListGroup>
       </Col>

--- a/src/views/ScopeGrants/ScopeGrants.jsx
+++ b/src/views/ScopeGrants/ScopeGrants.jsx
@@ -281,6 +281,7 @@ export default class ScopeGrants extends PureComponent {
   };
 
   renderPatternInstance(pattern, selected) {
+    const params = Object.keys(pattern.params);
     let arg = selected;
 
     if (this.state.error) {
@@ -294,13 +295,15 @@ export default class ScopeGrants extends PureComponent {
 
       const instantiatedArgs = instantiatedArguments(pattern, this.state.roles);
 
-      arg = instantiatedArgs.find(
-        element => element.organization === this.props.organization
+      params.map(
+        org =>
+          (arg = instantiatedArgs.find(
+            ele => ele[org] === this.props.organization
+          ))
       );
     }
 
     const args = arg;
-    const params = Object.keys(pattern.params);
 
     return (
       <span>

--- a/src/views/ScopeGrants/index.jsx
+++ b/src/views/ScopeGrants/index.jsx
@@ -4,6 +4,7 @@ import ScopeGrants from './ScopeGrants';
 
 const View = ({ match, history }) => {
   const pattern = decodeURIComponent(match.params.pattern || '');
+  const organization = decodeURIComponent(match.params.organization || '');
 
   return (
     <WithUserSession>
@@ -15,6 +16,7 @@ const View = ({ match, history }) => {
               history={history}
               userSession={userSession}
               pattern={pattern}
+              organization={organization}
             />
           )}
         </WithClients>


### PR DESCRIPTION
Link to [Bug 1442237](https://bugzilla.mozilla.org/show_bug.cgi?id=1442237)

Some thoughts and concerns:
1. Features
* have 3 separate views for Scope Grants as stated in the bug description
* properly display view/delete page when users navigate to it by typing in url (I understand that we want to eliminate page reload in single page app, but we have no control over users' behavior I guess esp. when child urls here are not that long like other type of edit pages)
* derived from the above one: display an error when the page users search for does not exist
2. Testing
* I couldn't actually test delete/create grants part as it seems I don't have enough credentials
* Not sure how it will do when there are more supported scope patterns with more than 1 params and grants
3. Error handling
* Now when users search for a non-exist organization: /auth/grants/authorize-github-organizations/aaa, the errors displayed are `Cannot read property '[object Array]' of undefined` with method stacks, not quite user friendly. 
It's thrown by `this.props.auth.listRoles()` of which I couldn't find its implementation in this project and am curious where it is.

Also, as for variable/function namings, I am trying to follow the existing style, and do suggest better ones if you like. Thanks