### PR TITLE
Do not reload actions when socket reconnects

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-vnc-display": "^1.1.0",
     "shebang-loader": "0.0.1",
     "slugid": "^1.1.0",
-    "taskcluster-client-web": "^6.0.0",
+    "taskcluster-client-web": "^7.0.0",
     "taskcluster-lib-scopes": "^1.1.5",
     "ws-shell": "0.1.5",
     "www-authenticate": "0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9060,9 +9060,9 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-taskcluster-client-web@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-client-web/-/taskcluster-client-web-6.0.0.tgz#1464255089476b32b0ddf8986b4e04dbb3f992d7"
+taskcluster-client-web@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client-web/-/taskcluster-client-web-7.0.0.tgz#a05a4c7f629fee2f5472e499c16dedb78781ff54"
   dependencies:
     hawk "^6.0.2"
     query-string "^5.0.0"


### PR DESCRIPTION
[![bug 1455063](https://img.shields.io/bugzilla/1455063.svg?&style=flat-square)](https://bugzilla.mozilla.org/show_bug.cgi?id=1455063)

This is part 2 of a 2-part fix.

This first problem existed in taskcluster-client-web, since the actions.json request uses the fetching function from it. The retry logic was flawed, causing the condition to check for retries to not be calculated properly.

The second is being fixed here, which is to skip attempts to reload the actions.json request every time the socket reconnects. Why the socket reconnects, I am not sure, but at least this stops the polling, and limits the number of retries for this artifact to 1.