### PR TITLE
Fix LegacyRedirect for /task-inspector

### DIFF
--- a/src/App/LegacyRedirect.jsx
+++ b/src/App/LegacyRedirect.jsx
@@ -33,7 +33,9 @@ const LegacyRedirect = props => {
     }
 
     case '/task-inspector': {
-      return <Redirect to={`/tasks/${props.location.hash.slice(1)}`} />;
+      const taskId = props.location.hash.slice(1);
+
+      return <Redirect to={taskId ? `/tasks/${taskId}` : '/groups'} />;
     }
 
     case '/task-creator': {


### PR DESCRIPTION
As it was, this would send the user to /tasks which shows an error.

It'd be great if https://tools.taskcluster.net/tasks/ showed the same thing as https://tools.taskcluster.net/groups/ or redirected.. but I can't quite figure out what is causing that error.