### PR TITLE
Bug 1380540 - use an extra line to make the last line visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-hot-loader": "^3.0.0",
     "react-input-enhancements": "^0.5.4",
     "react-json-inspector": "^7.1.0",
-    "react-lazylog": "^1.2.0",
+    "react-lazylog": "2.2.0",
     "react-loadable": "^4.0.5",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.2.2",

--- a/src/views/UnifiedInspector/LogView.jsx
+++ b/src/views/UnifiedInspector/LogView.jsx
@@ -251,6 +251,7 @@ export default class LogView extends PureComponent {
               highlight={highlight}
               onHighlight={onHighlight}
               onScroll={this.handleScroll}
+              extraLines={1}
             />
           )}
         </ScrollFollow>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4849,6 +4849,10 @@ immutable@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
 
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
 import-inspector@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-inspector/-/import-inspector-2.0.0.tgz#ce75fdb6a277d2800effe097e2295bc8690b2923"
@@ -7743,15 +7747,15 @@ react-json-inspector@^7.1.0:
     object-assign "2.0.0"
     prop-types "^15.5.10"
 
-react-lazylog@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-1.2.0.tgz#b7a1e79d22d8e2a4fc8aa3cc2accfb5022ec1f31"
+react-lazylog@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-2.2.0.tgz#f632870e2887af04661ddc43e9ca277ab42a7e4c"
   dependencies:
     fetch-readablestream "^0.1.0"
-    immutable "^3.8.1"
+    immutable "^3.8.2"
     mitt "^1.1.2"
     react-hot-loader "^3.0.0-beta.7"
-    react-virtualized "^9.9.0"
+    react-virtualized "^9.10.1"
     text-encoding-utf-8 "^1.0.1"
     web-streams-polyfill "^1.3.2"
     whatwg-fetch "^2.0.3"
@@ -7850,15 +7854,15 @@ react-treeview@^0.4.7:
   dependencies:
     prop-types "^15.5.8"
 
-react-virtualized@^9.9.0:
-  version "9.9.0"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.9.0.tgz#799a6f23819eeb82860d59b82fad33d1d420325e"
+react-virtualized@^9.10.1:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
   dependencies:
-    babel-runtime "^6.11.6"
+    babel-runtime "^6.26.0"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"
-    prop-types "^15.5.4"
+    prop-types "^15.6.0"
 
 react-vnc-display@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This will also require an upgrade to react-lazylog 2.2.0 or however https://github.com/mozilla-frontend-infra/react-lazylog/pull/14 is released.