### PR TITLE
Bug 1472831 - fix unnecessary resetting of role editor

### DIFF
--- a/src/components/RoleEditor/index.jsx
+++ b/src/components/RoleEditor/index.jsx
@@ -56,7 +56,7 @@ export default class RoleEditor extends PureComponent {
       this.setState({ error: null });
     }
 
-    if (!nextProps.currentRoleId !== this.props.currentRoleId) {
+    if (nextProps.currentRoleId !== this.props.currentRoleId) {
       this.load(nextProps);
     }
   }


### PR DESCRIPTION
Just a superfluous `!` causing the comparison to always be true..