### PR TITLE
Bug 1472792 - select the lowest-ordered action of a given name

### DIFF
--- a/src/views/UnifiedInspector/ActionsMenu.jsx
+++ b/src/views/UnifiedInspector/ActionsMenu.jsx
@@ -77,6 +77,29 @@ export default class ActionsMenu extends PureComponent {
 
       if (actions && actions.actions) {
         actions.actions.forEach(action => {
+          if (!knownKinds.includes(action.kind)) {
+            return;
+          }
+
+          // if an action with this name has already been selected,
+          // don't consider this version
+          if (actionData[action.name]) {
+            return;
+          }
+
+          // add the action if it is a match; otherwise bail out
+          if (!action.context.length) {
+            groupActions.push(action.name);
+          } else if (
+            task &&
+            task.tags &&
+            this.taskInContext(action.context, task.tags)
+          ) {
+            taskActions.push(action.name);
+          } else {
+            return;
+          }
+
           const schema = action.schema || {};
           const validate = this.ajv.compile(schema);
 
@@ -87,20 +110,6 @@ export default class ActionsMenu extends PureComponent {
             action,
             validate
           };
-
-          if (!knownKinds.includes(action.kind)) {
-            return;
-          }
-
-          if (!action.context.length) {
-            groupActions.push(action.name);
-          } else if (
-            task &&
-            task.tags &&
-            this.taskInContext(action.context, task.tags)
-          ) {
-            taskActions.push(action.name);
-          }
         });
       }
 


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster-docs/pull/270

We'll need to do the same for treeherder.

This can be tested on https://treeherder.mozilla.org/#/jobs?repo=try&revision=0e08ac79027a3395abf12cfd6fff0f6d4a442913&selectedJob=186904294 which has both a mochitest (that should get a mochitest-specific retrigger action) and other tasks (that should get a "regular" retrigger)