### PR TITLE
Stop the running bar animation

### DIFF
--- a/src/views/UnifiedInspector/GroupProgress.jsx
+++ b/src/views/UnifiedInspector/GroupProgress.jsx
@@ -129,7 +129,6 @@ export default class GroupProgress extends PureComponent {
                   : labels[group]
               }
               style={group === 'unscheduled' ? { background: '#777' } : null}
-              active={group === 'running'}
               now={(percents[group] / weightedTotal) * 100}
               label={
                 tasks.length


### PR DESCRIPTION
Webrender doesn't support async animation of this property so it's causing a constant scene rebuild.

https://bugzilla.mozilla.org/show_bug.cgi?id=1465792