### PR TITLE
Stop using WebListener in tools

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -99,12 +99,16 @@ export const parameterizeTask = task =>
   );
 
 export const createListener = options => {
-  const bindings = options.exchanges.map(exchange =>
-    (({ exchange, routingKeyPattern }) => ({
-      exchange,
-      routingKeyPattern
-    }))(options.queueEvents[exchange](options.routingKey))
-  );
+  let { bindings } = options;
+
+  if (!bindings) {
+    bindings = options.exchanges.map(exchange =>
+      (({ exchange, routingKeyPattern }) => ({
+        exchange,
+        routingKeyPattern
+      }))(options.queueEvents[exchange](options.routingKey))
+    );
+  }
 
   return new EventSource(`
     https://taskcluster-events-staging.herokuapp.com/v1/connect/?bindings=${encodeURIComponent(

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,7 @@ export const parameterizeTask = task =>
     }
   );
 
-export const createEventsListener = options => {
+export const createListener = options => {
   const bindings = options.exchanges.map(exchange =>
     (({ exchange, routingKeyPattern }) => ({
       exchange,

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,15 +99,11 @@ export const parameterizeTask = task =>
   );
 
 export const createEventsListener = options => {
-  const bindings = [];
-
-  options.exchanges.map(exchange =>
-    bindings.push(
-      (({ exchange, routingKeyPattern }) => ({
-        exchange,
-        routingKeyPattern
-      }))(options.queueEvents[exchange](options.routingKey))
-    )
+  const bindings = options.exchanges.map(exchange =>
+    (({ exchange, routingKeyPattern }) => ({
+      exchange,
+      routingKeyPattern
+    }))(options.queueEvents[exchange](options.routingKey))
   );
 
   return new EventSource(`

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,6 +98,24 @@ export const parameterizeTask = task =>
     }
   );
 
+export const createEventsListener = options => {
+  const bindings = [];
+
+  options.exchanges.map(exchange =>
+    bindings.push(
+      (({ exchange, routingKeyPattern }) => ({
+        exchange,
+        routingKeyPattern
+      }))(options.queueEvents[exchange](options.routingKey))
+    )
+  );
+
+  return new EventSource(`
+    https://taskcluster-events-staging.herokuapp.com/v1/connect/?bindings=${encodeURIComponent(
+      JSON.stringify({ bindings })
+    )}`);
+};
+
 // toArray :: a -> Array
 export const toArray = cond([[Array.isArray, identity], [T, of]]);
 

--- a/src/views/InteractiveConnect/InteractiveConnect.jsx
+++ b/src/views/InteractiveConnect/InteractiveConnect.jsx
@@ -7,7 +7,7 @@ import Error from '../../components/Error';
 import Spinner from '../../components/Spinner';
 import Markdown from '../../components/Markdown';
 import HelmetTitle from '../../components/HelmetTitle';
-import { labels, createEventsListener } from '../../utils';
+import { labels, createListener } from '../../utils';
 import iconUrl from './terminal.png';
 import { connectLinkButton, connectLinkText } from './styles.module.css';
 import UserSession from '../../auth/UserSession';
@@ -114,7 +114,7 @@ export default class InteractiveConnect extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const listener = createEventsListener({
+    const listener = createListener({
       queueEvents,
       exchanges: [
         'taskDefined',

--- a/src/views/InteractiveConnect/InteractiveConnect.jsx
+++ b/src/views/InteractiveConnect/InteractiveConnect.jsx
@@ -114,19 +114,17 @@ export default class InteractiveConnect extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const routingKey = { taskId };
-    const exchanges = [
-      'taskDefined',
-      'taskPending',
-      'taskRunning',
-      'taskCompleted',
-      'taskFailed',
-      'taskException'
-    ];
     const listener = createEventsListener({
       queueEvents,
-      exchanges,
-      routingKey
+      exchanges: [
+        'taskDefined',
+        'taskPending',
+        'taskRunning',
+        'taskCompleted',
+        'taskFailed',
+        'taskException'
+      ],
+      routingKey: { taskId }
     });
 
     listener.addEventListener('message', msg =>

--- a/src/views/PulseInspector/index.jsx
+++ b/src/views/PulseInspector/index.jsx
@@ -16,7 +16,7 @@ import { pick } from 'ramda';
 import { parse, stringify } from 'qs';
 import MessageRow from './MessageRow';
 import HelmetTitle from '../../components/HelmetTitle';
-import { urls } from '../../utils';
+import { urls, createListener } from '../../utils';
 
 export default class PulseInspector extends PureComponent {
   static defaultProps = {
@@ -78,10 +78,7 @@ export default class PulseInspector extends PureComponent {
       return;
     }
 
-    const jsonBindings = encodeURIComponent(JSON.stringify({ bindings }));
-    const listener = new EventSource(
-      urls.api('events', 'v1', `connect/?bindings=${jsonBindings}`)
-    );
+    const listener = createListener({ bindings });
 
     listener.addEventListener('message', this.handleListenerMessage);
     listener.addEventListener('error', ({ data }) => {

--- a/src/views/UnifiedInspector/Inspector.jsx
+++ b/src/views/UnifiedInspector/Inspector.jsx
@@ -295,19 +295,17 @@ export default class Inspector extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const routingKey = { taskGroupId };
-    const exchanges = [
-      'taskDefined',
-      'taskPending',
-      'taskRunning',
-      'taskCompleted',
-      'taskFailed',
-      'taskException'
-    ];
     const listener = createEventsListener({
       queueEvents,
-      exchanges,
-      routingKey
+      exchanges: [
+        'taskDefined',
+        'taskPending',
+        'taskRunning',
+        'taskCompleted',
+        'taskFailed',
+        'taskException'
+      ],
+      routingKey: { taskGroupId }
     });
 
     listener.addEventListener('message', msg =>
@@ -330,12 +328,10 @@ export default class Inspector extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const routingKey = { taskId };
-    const exchanges = ['artifactCreated'];
     const listener = createEventsListener({
       queueEvents,
-      exchanges,
-      routingKey
+      exchanges: ['artifactCreated'],
+      routingKey: { taskId }
     });
 
     listener.addEventListener('message', msg =>

--- a/src/views/UnifiedInspector/Inspector.jsx
+++ b/src/views/UnifiedInspector/Inspector.jsx
@@ -16,7 +16,7 @@ import ArtifactList from '../../components/ArtifactList';
 import successFavIcon from '../../images/taskcluster-group-success.png';
 import pendingFavIcon from '../../images/taskcluster-group-pending.png';
 import failedFavIcon from '../../images/taskcluster-group-failed.png';
-import { loadable, createEventsListener } from '../../utils';
+import { loadable, createListener } from '../../utils';
 import UserSession from '../../auth/UserSession';
 
 const GroupProgress = loadable(() =>
@@ -295,7 +295,7 @@ export default class Inspector extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const listener = createEventsListener({
+    const listener = createListener({
       queueEvents,
       exchanges: [
         'taskDefined',
@@ -328,7 +328,7 @@ export default class Inspector extends PureComponent {
     }
 
     const { queueEvents } = this.props;
-    const listener = createEventsListener({
+    const listener = createListener({
       queueEvents,
       exchanges: ['artifactCreated'],
       routingKey: { taskId }


### PR DESCRIPTION
When we landed #544 , couple tools services like the `InteractiveConnect` and `UnifiedInspector` still used `WebListener`.
This PR makes them free of that. i have retained the heroku staging url here for some testing by @eliperelman 
Once tested, I will change to  `tc-libUrls` 
