### PR TITLE
Update auth0-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@neutrinojs/env": "^8.1.2",
     "@skidding/react-codemirror": "^1.0.2",
     "ajv": "^5.2.3",
-    "auth0-js": "^9.3.3",
+    "auth0-js": "^9.7.3",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^3.3.7",
     "change-case": "^3.0.0",

--- a/src/views/Auth0Login/index.jsx
+++ b/src/views/Auth0Login/index.jsx
@@ -20,19 +20,22 @@ export default class Auth0Login extends PureComponent {
       return;
     }
 
-    webAuth.parseHash(window.location.hash, (loginError, authResult) => {
-      if (loginError) {
-        return this.setState({ loginError });
-      }
+    webAuth.parseHash(
+      { hash: window.location.hash },
+      (loginError, authResult) => {
+        if (loginError) {
+          return this.setState({ loginError });
+        }
 
-      this.props.setUserSession(userSessionFromAuthResult(authResult));
+        this.props.setUserSession(userSessionFromAuthResult(authResult));
 
-      if (window.opener) {
-        window.close();
-      } else {
-        history.push('/');
+        if (window.opener) {
+          window.close();
+        } else {
+          history.push('/');
+        }
       }
-    });
+    );
   }
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,9 +605,9 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
-auth0-js@^9.3.3:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.6.0.tgz#d9ae3014807366d3b479c2ad18a3537f3e0c9699"
+auth0-js@^9.7.3:
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.7.3.tgz#5d09a703e3758d50ee95d57d05b7f31271c1c821"
   dependencies:
     base64-js "^1.2.0"
     idtoken-verifier "^1.2.0"


### PR DESCRIPTION
In addition to updating the package version, the `parseHash` method seems to take an `options` object instead of a string. If no object provided then it will use `window.location.hash` by default.

https://auth0.com/docs/libraries/auth0js/v9#extract-the-authresult-and-get-user-info