### PR TITLE
Add unsafe-eval to CSP

### DIFF
--- a/static.json
+++ b/static.json
@@ -22,7 +22,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/*.*": {
@@ -31,7 +31,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/index.html": {
@@ -40,7 +40,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval'; font-src 'self' data:; img-src 'self' https:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     }
   }


### PR DESCRIPTION
Running the CSP headers introduced in https://github.com/taskcluster/taskcluster-tools/pull/563 seemed to work in production, however I had to rollback after seeing the group inspector not loading.

<img width="1673" alt="screen shot 2018-08-17 at 2 02 50 pm" src="https://user-images.githubusercontent.com/3766511/44282479-33ba3400-a229-11e8-8c59-5b0871c4efa4.png">

There seems to be a call being made to `Function()` which is being blocked. After inspecting the issue, it turns out the `ajv.compile` uses `Function()` to inspect schemas at runtime. See [source ](https://github.com/epoberezkin/ajv/blob/5ebfe2c1f4074a5c460aa5e680f1b46ff87d45e8/lib/compile/index.js#L120).

That being said, to fix this issue, we need to update the `script-src` to include [`unsafe-eval`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_eval_expressions). Hopefully this fixes it.

