### PR TITLE
CSP: Add wss://* to connect-src and data: to media-src

### DIFF
--- a/static.json
+++ b/static.json
@@ -22,7 +22,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/*.*": {
@@ -31,7 +31,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/index.html": {
@@ -40,7 +40,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     }
   }


### PR DESCRIPTION
Attempt to fix:

<img width="1674" alt="screen shot 2018-08-17 at 5 24 49 pm" src="https://user-images.githubusercontent.com/3766511/44290732-1cd70a00-a248-11e8-8175-1ccd0758fa1c.png">

For the first error, I don't think the scheme `wss:` is available to use according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src#Sources. Because of that, I used `wss://*`.

For the second error, media sound had to be allowed via media-src.