### PR TITLE
Bug 1441832 - Add form-action and base-uri to CSP rules

### DIFF
--- a/static.json
+++ b/static.json
@@ -22,7 +22,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/*.*": {
@@ -31,7 +31,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/index.html": {
@@ -40,7 +40,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     }
   }


### PR DESCRIPTION
### CSP: base-uri

We don't seem to make use of the `base` tag so we can add `base-uri 'none'` in our CSP rules. The generated `index.html` after a build shows:

```html
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta content="ie=edge" http-equiv="x-ua-compatible">
<meta name="description" content="A collection of tools for Taskcluster components and elements in the
                Taskcluster ecosystem. Here you'll find tools to manage
                Taskcluster services as well as run, debug, inspect, and view tasks, task groups,
                and other Taskcluster related entities.">
<meta name="author" content="Taskcluster">
<title>Taskcluster</title>
<meta content="width=device-width,initial-scale=1" name="viewport">
<link href="/index.b9ec9f27fa848ae9cea54954892eb073.css" rel="stylesheet"/>
</head>
<body>
<div id="root">
</div>
<script src="/runtime.6b17f7b8acc17981bfde.v1.js" type="text/javascript"></script>
<script src="/vendor.14cd42690447ff5ce934.v1.js" type="text/javascript"></script>
<script src="/index.f55880b24bc0d4c01012.v1.js" type="text/javascript"></script>
</body>
</html>
```

### CSP: form-action

When a form is submitted, we always do `e.preventDefault` so I think it's safe to add `form-action 'none'` to our CSP rules.