### PR TITLE
Bug 1474953 - catch task status 404s and show in table

### DIFF
--- a/src/views/WorkerManager/WorkerManager.jsx
+++ b/src/views/WorkerManager/WorkerManager.jsx
@@ -128,13 +128,17 @@ export default class WorkerManager extends PureComponent {
           workerGroup,
           workerId
         );
+
+        // Display worker data while loading tasks.
+        this.setState({ worker, recentTasks: [{}] });
+
         const recentTasks = await this.handleLoadRecentTasks(
           worker.recentTasks
         );
 
-        this.setState({ worker, recentTasks, loading: false, error: null });
+        this.setState({ recentTasks, loading: false });
       } catch (error) {
-        this.setState({ worker: null, recentTasks: [], loading: false, error });
+        this.setState({ loading: false, error });
       }
     });
   };
@@ -143,8 +147,8 @@ export default class WorkerManager extends PureComponent {
     Promise.all(
       recentTasks.map(async ({ taskId, runId }) => {
         const [task, { status }] = await Promise.all([
-          this.props.queue.task(taskId),
-          this.props.queue.status(taskId)
+          this.props.queue.task(taskId).catch(() => taskId),
+          this.props.queue.status(taskId).catch(e => e)
         ]);
 
         return { task, status, runId };

--- a/src/views/WorkerManager/WorkerTable.jsx
+++ b/src/views/WorkerManager/WorkerTable.jsx
@@ -54,7 +54,7 @@ export default class WorkerTable extends PureComponent {
   );
 
   renderTask = ({ task, status, runId }, index) => {
-    if (status === undefined) {
+    if (!status) {
       return (
         <tr key={`recent-task-${index}`}>
           <td />
@@ -122,7 +122,7 @@ export default class WorkerTable extends PureComponent {
 
     const sort = tasks =>
       tasks.sort((a, b) => {
-        if (a.status === undefined || b.status === undefined) {
+        if (!a.status || !b.status) {
           return 0;
         }
 
@@ -141,8 +141,7 @@ export default class WorkerTable extends PureComponent {
       return sort(
         tasks.filter(
           task =>
-            task.status !== undefined &&
-            task.status.runs[task.runId].state === filterStatus
+            task.status && task.status.runs[task.runId].state === filterStatus
         )
       );
     }

--- a/src/views/WorkerManager/WorkerTable.jsx
+++ b/src/views/WorkerManager/WorkerTable.jsx
@@ -54,6 +54,18 @@ export default class WorkerTable extends PureComponent {
   );
 
   renderTask = ({ task, status, runId }, index) => {
+    if (status === undefined) {
+      return (
+        <tr key={`recent-task-${index}`}>
+          <td />
+          <td />
+          <td>{task}</td>
+          <td />
+          <td />
+        </tr>
+      );
+    }
+
     const run = status.runs[runId];
     const description = this.renderTaskDescription(task.metadata);
 
@@ -110,6 +122,10 @@ export default class WorkerTable extends PureComponent {
 
     const sort = tasks =>
       tasks.sort((a, b) => {
+        if (a.status === undefined || b.status === undefined) {
+          return 0;
+        }
+
         const diff = moment(a.status.runs[a.runId].started).diff(
           moment(b.status.runs[b.runId].started)
         );
@@ -124,7 +140,9 @@ export default class WorkerTable extends PureComponent {
     if (filterStatus !== 'all') {
       return sort(
         tasks.filter(
-          task => task.status.runs[task.runId].state === filterStatus
+          task =>
+            task.status !== undefined &&
+            task.status.runs[task.runId].state === filterStatus
         )
       );
     }


### PR DESCRIPTION
When a task is not found (queue task and status requests), the worker explorer currently shows an error for the first task not found. As a user, I would like to see the worker information (first claim, and action buttons), and any valid tasks as well as the unknown task ids.

Example worker view:
https://tools.taskcluster.net/provisioners/releng-hardware/worker-types/gecko-t-osx-1010/workers/mdc1/t-yosemite-r7-273

Before:
![image](https://user-images.githubusercontent.com/5540936/47527088-e4af0180-d85e-11e8-9e1a-4f671248530f.png)

After:
![image](https://user-images.githubusercontent.com/5540936/47527145-0ad4a180-d85f-11e8-898e-abea37693e42.png)
