### PR TITLE
Bug1474953 Expect tasks to be in reverse order

### DIFF
--- a/src/views/WorkerManager/WorkerManager.jsx
+++ b/src/views/WorkerManager/WorkerManager.jsx
@@ -133,7 +133,7 @@ export default class WorkerManager extends PureComponent {
         this.setState({ worker, recentTasks: [{}] });
 
         const recentTasks = await this.handleLoadRecentTasks(
-          worker.recentTasks
+          worker.recentTasks.reverse()
         );
 
         this.setState({ recentTasks, loading: false });


### PR DESCRIPTION
The taskcluster.queue.getWorker(https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/api#getWorker) recentTasks list is usually in reverse chronological order. And we sort by default in reverse chronological order. So, reverse the list when we get it and before we manually sort the elements.

@helfi92 I re-made the change on master.