### PR TITLE
Add Heroku GitHub integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,3 @@ after_failure:
 script:
 - yarn lint
 - travis_wait yarn build
-deploy:
-  app: taskcluster-tools
-  provider: heroku
-  skip_cleanup: true
-  on:
-    branch: master
-  api_key:
-    secure: at4cJRmc98kgJSypIeVDWOZP62Hk707d4Q4GhZ1Xr7QsZQV8rIJpbTcaS+naTqPp5tgrigu6if1LFpwCa6mjVACe6HxqeHqfUrmWPU/4/139GG0Jh240Z1CmyOGT3CNfcBrquGcYrFY7y//EBMW2eBG6XW47lFlA3joWLGBAqVI=

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "neutrino lint",
     "debug": "node --inspect ./node_modules/.bin/neutrino start --require dotenv/config",
     "build": "neutrino build --require dotenv/config",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "heroku-prebuild": "yarn install --frozen-lockfile"
   },
   "lint-staged": {
     "*.js*": [


### PR DESCRIPTION
I added the following env vars in Heroku https://github.com/taskcluster/taskcluster-tools/blob/46b8ccb2f209f4dc7a5ea667be29d0233a9b82b5/.env. I did however notice there were [2 additional variables](https://travis-ci.org/taskcluster/taskcluster-tools/settings) only defined in the Travis site, namely `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. I don't see them being used in the repository. Do we need them?

Once this is merged and things look ok, we should enable automatic deploys from Heroku.

Relates to #587. 