### PR TITLE
Bug 1491767 : purge-caches errors are not readable

### DIFF
--- a/src/views/CachePurgeInspector/CachePurgeInspector.jsx
+++ b/src/views/CachePurgeInspector/CachePurgeInspector.jsx
@@ -33,7 +33,11 @@ export default class CachePurgeInspector extends PureComponent {
   componentWillMount() {
     this.loadCaches();
   }
+  isFormValid = () => {
+    const { formProvisionerId, formWorkerType, formCacheName } = this.state;
 
+    return formProvisionerId && formWorkerType && formCacheName;
+  };
   componentWillReceiveProps(nextProps) {
     if (
       UserSession.userChanged(this.props.userSession, nextProps.userSession)
@@ -144,12 +148,6 @@ export default class CachePurgeInspector extends PureComponent {
   );
 
   renderForm() {
-    const { formProvisionerId, formWorkerType, formCacheName } = this.state;
-    const nonEmptyFields =
-      formProvisionerId.length > 0 &&
-      formWorkerType.length > 0 &&
-      formCacheName.length > 0;
-
     if (this.state.formError) {
       return (
         <Alert bsStyle="danger" onDismiss={this.handleDismissError}>
@@ -209,7 +207,7 @@ export default class CachePurgeInspector extends PureComponent {
           <Button
             bsStyle="primary"
             onClick={this.handleSendRequest}
-            disabled={!nonEmptyFields}>
+            disabled={this.isFormValid}>
             <Glyphicon glyph="plus" /> Create request
           </Button>
         </ButtonToolbar>

--- a/src/views/CachePurgeInspector/CachePurgeInspector.jsx
+++ b/src/views/CachePurgeInspector/CachePurgeInspector.jsx
@@ -68,8 +68,6 @@ export default class CachePurgeInspector extends PureComponent {
     this.setState({ formCacheName: event.target.value });
 
   handleSendRequest = async () => {
-    const { formProvisionerId, formWorkerType, formCacheName } = this.state;
-
     try {
       await this.props.purgeCache.purgeCache(
         formProvisionerId,
@@ -144,6 +142,11 @@ export default class CachePurgeInspector extends PureComponent {
   );
 
   renderForm() {
+    const { formProvisionerId, formWorkerType, formCacheName } = this.state;
+    const nonEmptyFields=
+        formProvisionerId.length > 0 &&
+        formWorkerType.length > 0 &&
+        formCacheName.length > 0;
     if (this.state.formError) {
       return (
         <Alert bsStyle="danger" onDismiss={this.handleDismissError}>
@@ -200,7 +203,7 @@ export default class CachePurgeInspector extends PureComponent {
         </p>
 
         <ButtonToolbar>
-          <Button bsStyle="primary" onClick={this.handleSendRequest}>
+          <Button bsStyle="primary" onClick={this.handleSendRequest} disabled={nonEmptyFields}>
             <Glyphicon glyph="plus" /> Create request
           </Button>
         </ButtonToolbar>

--- a/src/views/CachePurgeInspector/CachePurgeInspector.jsx
+++ b/src/views/CachePurgeInspector/CachePurgeInspector.jsx
@@ -68,6 +68,8 @@ export default class CachePurgeInspector extends PureComponent {
     this.setState({ formCacheName: event.target.value });
 
   handleSendRequest = async () => {
+    const { formProvisionerId, formWorkerType, formCacheName } = this.state;
+
     try {
       await this.props.purgeCache.purgeCache(
         formProvisionerId,
@@ -143,10 +145,11 @@ export default class CachePurgeInspector extends PureComponent {
 
   renderForm() {
     const { formProvisionerId, formWorkerType, formCacheName } = this.state;
-    const nonEmptyFields=
-        formProvisionerId.length > 0 &&
-        formWorkerType.length > 0 &&
-        formCacheName.length > 0;
+    const nonEmptyFields =
+      formProvisionerId.length > 0 &&
+      formWorkerType.length > 0 &&
+      formCacheName.length > 0;
+
     if (this.state.formError) {
       return (
         <Alert bsStyle="danger" onDismiss={this.handleDismissError}>
@@ -203,7 +206,10 @@ export default class CachePurgeInspector extends PureComponent {
         </p>
 
         <ButtonToolbar>
-          <Button bsStyle="primary" onClick={this.handleSendRequest} disabled={nonEmptyFields}>
+          <Button
+            bsStyle="primary"
+            onClick={this.handleSendRequest}
+            disabled={!nonEmptyFields}>
             <Glyphicon glyph="plus" /> Create request
           </Button>
         </ButtonToolbar>

--- a/src/views/CachePurgeInspector/CachePurgeInspector.jsx
+++ b/src/views/CachePurgeInspector/CachePurgeInspector.jsx
@@ -33,11 +33,13 @@ export default class CachePurgeInspector extends PureComponent {
   componentWillMount() {
     this.loadCaches();
   }
+
   isFormValid = () => {
     const { formProvisionerId, formWorkerType, formCacheName } = this.state;
 
     return formProvisionerId && formWorkerType && formCacheName;
   };
+
   componentWillReceiveProps(nextProps) {
     if (
       UserSession.userChanged(this.props.userSession, nextProps.userSession)
@@ -148,6 +150,8 @@ export default class CachePurgeInspector extends PureComponent {
   );
 
   renderForm() {
+    const isFormValid = this.isFormValid();
+
     if (this.state.formError) {
       return (
         <Alert bsStyle="danger" onDismiss={this.handleDismissError}>
@@ -207,7 +211,7 @@ export default class CachePurgeInspector extends PureComponent {
           <Button
             bsStyle="primary"
             onClick={this.handleSendRequest}
-            disabled={this.isFormValid}>
+            disabled={!isFormValid}>
             <Glyphicon glyph="plus" /> Create request
           </Button>
         </ButtonToolbar>


### PR DESCRIPTION
Create Request Button in cachePurgeInspector is disabled till all inputs are non empty

" Create request " was previously enabled when all or any of the inputs were empty resulting in unhandled and vague errors

Closes Bug 1491767 in bmo