### PR TITLE
Interactive Task: remove check for command property

### DIFF
--- a/src/views/UnifiedInspector/ActionsMenu.jsx
+++ b/src/views/UnifiedInspector/ActionsMenu.jsx
@@ -158,10 +158,6 @@ export default class ActionsMenu extends PureComponent {
       return false;
     }
 
-    if (!Array.isArray(payload.command)) {
-      return false;
-    }
-
     return typeof payload.maxRunTime === 'number';
   }
 


### PR DESCRIPTION
From IRC:

```
marco > pmoore: another question, for some reason "Create Interactive Task" is disabled on https://tools.taskcluster.net/groups/OAebBJN8Q-uJ87bLvhOq2Q/tasks/ZYVkdpARRWO2rJ0B_TCJfw/runs/3/logs/public%2Flogs%2Flive.log
pmoore > hassan: do you know why a command is required for interactive tasks when the docker image entry point can be used as the task command for non-interactive docker-worker tasks?
hassan > i'm not sure why a command is set as required for interactive tasks. we could try removing it
```