### PR TITLE
Interactive connect CSP

### DIFF
--- a/static.json
+++ b/static.json
@@ -22,7 +22,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss:; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/*.*": {
@@ -31,7 +31,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     },
     "/index.html": {
@@ -40,7 +40,7 @@
       "X-Content-Type-Options": "nosniff",
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin",
-      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://*; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
+      "Content-Security-Policy": "default-src 'none'; connect-src 'self' https: wss://; media-src data:; script-src 'self' 'unsafe-eval' https:; font-src 'self' data:; img-src 'self' https: data:; style-src https: 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; frame-src 'self' https://auth.mozilla.auth0.com; base-uri 'none'; form-action 'none'",
       "Strict-Transport-Security": "max-age=31536000; includeSubDomains; always;"
     }
   }


### PR DESCRIPTION
The interactive connect feature doesn't work on Firefox & Chrome but works on Safari. I'm not sure why but probably because safari is more lenient. My hope is that this will fix the issue (untested).

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src#Syntax