### PR TITLE
Add a banner pointing users to new deployments

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -6,6 +6,7 @@ import { Grid } from 'react-bootstrap';
 import PropsRoute from '../components/PropsRoute';
 import Navigation from '../components/Navigation';
 import NotFound from '../components/NotFound';
+import TaskclusterWebBanner from '../components/TaskclusterWebBanner';
 import { loadable } from '../utils';
 import './styles.css';
 import iconUrl from '../taskcluster.png';
@@ -169,6 +170,7 @@ export default class App extends Component {
           </Helmet>
           <PropsRoute component={Navigation} />
           <Grid fluid id="container">
+            <TaskclusterWebBanner />
             {authReady ? (
               <Switch>
                 <PropsRoute

--- a/src/components/TaskclusterWebBanner/index.jsx
+++ b/src/components/TaskclusterWebBanner/index.jsx
@@ -34,15 +34,22 @@ export default class TaskclusterWebBanner extends PureComponent {
     return (
       open && (
         <Alert bsStyle="warning" onDismiss={this.handleAlertClose}>
-          <h4>Try our new site and tell us what you think</h4>
+          <h4>This deployment of Taskcluster will shut down on November 9.</h4>
           {children}
           <hr className={horizontalRule} />
           <div className={footer}>
             <small>
-              Report bugs or missing features by{' '}
-              <a href="https://github.com/taskcluster/taskcluster/issues/new">
-                creating an issue
-              </a>.
+              After that date, access either the{' '}
+              <a href="https://firefox-ci-tc.services.mozilla.com/">
+                Firefox-CI
+              </a>{' '}
+              deployment or the{' '}
+              <a href="https://community-tc.services.mozilla.com/">
+                Community-TC
+              </a>{' '}
+              deployment, depending on the project you are looking for. This
+              deployment will remain, but in a read-only mode, for several
+              months to keep existing URLs functional.
             </small>
           </div>
         </Alert>

--- a/src/views/Home/index.jsx
+++ b/src/views/Home/index.jsx
@@ -6,14 +6,7 @@ import chunk from 'lodash.chunk';
 import Markdown from '../../components/Markdown';
 import HelmetTitle from '../../components/HelmetTitle';
 import links from '../../links';
-import {
-  header,
-  hero,
-  logo,
-  entries,
-  entry,
-  description
-} from './styles.module.css';
+import { entries, entry, description } from './styles.module.css';
 
 // Please make sure that link matches location.pathname for the page otherwise
 // we won't be able to detect which page you're currently on.
@@ -24,16 +17,6 @@ export default class Home extends PureComponent {
     return (
       <div className={entries}>
         <HelmetTitle blank />
-        <Row className={hero}>
-          <Col md={8} mdOffset={2} sm={10} smOffset={1}>
-            <div className={header}>
-              <h2>
-                Welcome to{' '}
-                <span className={logo}>{process.env.APPLICATION_NAME}</span>
-              </h2>
-            </div>
-          </Col>
-        </Row>
         <Row className={description}>
           <Col sm={12}>
             <p>

--- a/src/views/UnifiedInspector/Inspector.jsx
+++ b/src/views/UnifiedInspector/Inspector.jsx
@@ -8,7 +8,6 @@ import { isNil, equals } from 'ramda';
 import Helmet from 'react-helmet';
 import PropsRoute from '../../components/PropsRoute';
 import Error from '../../components/Error';
-import TaskclusterWebBanner from '../../components/TaskclusterWebBanner';
 import SearchForm from './SearchForm';
 import ActionsMenu from './ActionsMenu';
 import RunsMenu from './RunsMenu';
@@ -19,7 +18,6 @@ import pendingFavIcon from '../../images/taskcluster-group-pending.png';
 import failedFavIcon from '../../images/taskcluster-group-failed.png';
 import { loadable, createListener } from '../../utils';
 import UserSession from '../../auth/UserSession';
-import { newSiteBanner } from './styles.module.css';
 
 const GroupProgress = loadable(() =>
   import(/* webpackChunkName: 'GroupProgress' */ './GroupProgress')
@@ -743,30 +741,6 @@ export default class Inspector extends PureComponent {
           <title>{`${task ? task.metadata.name : 'Task Inspector'}`}</title>
           <link rel="shortcut icon" type="image/png" href={FavIcon} />
         </Helmet>
-        <TaskclusterWebBanner>
-          <div className={newSiteBanner}>
-            <div>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={`https://taskcluster-ui.herokuapp.com/tasks/groups${
-                  taskGroupId ? `/${taskGroupId}` : ''
-                }`}>
-                Group View
-              </a>
-            </div>
-            <div>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={`https://taskcluster-ui.herokuapp.com/tasks${
-                  taskId ? `/${taskId}` : ''
-                }`}>
-                Task View
-              </a>
-            </div>
-          </div>
-        </TaskclusterWebBanner>
         <h4>Task &amp; Group Inspector</h4>
         <Row>
           <Col xs={12}>


### PR DESCRIPTION
I dropped the banner sending people to the taskcluster-ui.herokuapp.com site since that will soon be the default.  I also dropped the "Welcome To Taskcluster" banner on Home since it didn't look good with this banner.